### PR TITLE
Handle device unavailable better

### DIFF
--- a/custom_components/xtool/sensor.py
+++ b/custom_components/xtool/sensor.py
@@ -59,9 +59,13 @@ class XToolSensor(Entity):
                 _LOGGER.warning("Unknown device type: %s", self._device_type)
                 self._state = "Unknown"
                 self._attributes = {}
+        except requests.exceptions.ConnectionError as e:
+            _LOGGER.debug("Connection error while fetching data from XTool: %s", e)
+            self._state = "Unavailable"
+            self._attributes = {}
         except Exception as e:
             _LOGGER.error("Error fetching data from XTool: %s", e)
-            self._state = "off"
+            self._state = "Unavailable"
             self._attributes = {}
 
     def _map_mode(self, mode):


### PR DESCRIPTION
As is, HA log gets spammed by the following errors when XTool is powered off:

```
2025-08-09 11:52:46.097 ERROR (SyncWorker_7) [custom_components.xtool.sensor] Unable to connect to XTool: HTTPConnectionPool(host='***', port=8080): Max retries exceeded with url: /status (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7f92e56e3680>: Failed to establish a new connection: [Errno 113] Host is unreachable'))
```

To reduce the error quantity, we can handle the failure to connect exception explicitly and only produce debug level log event.

Further, with any exception, mark the state as `Unavailable` instead of `off`, as that seem more accurate.