### PR TITLE
Add comprehensive support for M1 Ultra (Sleep fix, Tool Detection, Knife Sync, Exhaust Switch)

### DIFF
--- a/custom_components/xtool/__init__.py
+++ b/custom_components/xtool/__init__.py
@@ -13,13 +13,8 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .coordinator_d1 import XToolD1Coordinator
 from .const import (
-    DOMAIN,
-    PLATFORMS,
-    CONF_IP_ADDRESS,
-    CONF_DEVICE_TYPE,
-    DEFAULT_UPDATE_INTERVAL,
-    DEFAULT_SLOW_UPDATE_INTERVAL,
-    HTTP_TIMEOUT,
+    DOMAIN, PLATFORMS, CONF_IP_ADDRESS, CONF_DEVICE_TYPE,
+    DEFAULT_UPDATE_INTERVAL, DEFAULT_SLOW_UPDATE_INTERVAL, HTTP_TIMEOUT
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -27,355 +22,337 @@ CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 
 def _safe_json(resp: requests.Response) -> Any:
+    """Helper to safely parse JSON responses."""
     try:
         return resp.json()
-    except Exception:  # noqa: BLE001
+    except Exception:
         return (resp.text or "").strip()
 
 
 def _is_invalid_or_not_supported(payload: Any) -> bool:
+    """Check if the API returned an unsupported or invalid request error."""
     if isinstance(payload, str):
         s = payload.strip().lower()
         return s in {"invalid request", "not support", "not supported"}
     if isinstance(payload, dict) and payload.get("code") == 10:
-        msg = str(payload.get("msg", "")).lower()
-        return "device not support" in msg
+        return "device not support" in str(payload.get("msg", "")).lower()
     return False
 
 
 class XToolCoordinator(DataUpdateCoordinator[dict[str, Any]]):
-    """Coordinator for P2/F1/M1 (v2 endpoints) + legacy fallback."""
-
+    """Coordinator for P2/F1/M1/M1 Ultra (v2 endpoints) + legacy fallback."""
     def __init__(self, hass: HomeAssistant, ip_address: str, device_type: str) -> None:
         super().__init__(
-            hass,
-            _LOGGER,
-            name=f"xtool_{ip_address}",
-            update_interval=timedelta(seconds=DEFAULT_UPDATE_INTERVAL),
+            hass, _LOGGER, name=f"xtool_{ip_address}", 
+            update_interval=timedelta(seconds=DEFAULT_UPDATE_INTERVAL)
         )
         self.ip_address = ip_address
         self.device_type = device_type.lower()
-
         self._reachable_last: bool | None = None
-
-        self._slow_every = max(
-            1, int(DEFAULT_SLOW_UPDATE_INTERVAL / max(1, DEFAULT_UPDATE_INTERVAL))
-        )
+        self._slow_every = max(1, int(DEFAULT_SLOW_UPDATE_INTERVAL / max(1, DEFAULT_UPDATE_INTERVAL)))
         self._tick = 0
-
         self._cached_machine_info: dict[str, Any] | None = None
         self._cached_working_info: dict[str, Any] | None = None
         self._cached_config: dict[str, Any] | None = None
-
         self._warnings_hash_last: str | None = None
 
     def _get(self, path: str) -> Any:
+        """Send a GET request to the device."""
         url = f"http://{self.ip_address}:8080{path}"
         resp = requests.get(url, timeout=HTTP_TIMEOUT)
         resp.raise_for_status()
         return _safe_json(resp)
 
     def _post(self, path: str, payload: dict[str, Any]) -> Any:
+        """Send a POST request to the device."""
         url = f"http://{self.ip_address}:8080{path}"
         resp = requests.post(url, json=payload, timeout=HTTP_TIMEOUT)
         resp.raise_for_status()
         return _safe_json(resp)
 
     def _warnings_list(self, alarm_obj: Any) -> list[dict[str, Any]]:
-        out: list[dict[str, Any]] = []
+        """Extract warning objects into a standard list."""
         if not isinstance(alarm_obj, dict):
-            return out
-
+            return []
         alarm_list = alarm_obj.get("alarm")
         if isinstance(alarm_list, list):
             return [a for a in alarm_list if isinstance(a, dict)]
-
-        for k, v in alarm_obj.items():
-            if str(k).isdigit() and isinstance(v, dict):
-                out.append(v)
-        return out
+        return [v for k, v in alarm_obj.items() if str(k).isdigit() and isinstance(v, dict)]
 
     def _warnings_summary(self, warnings: list[dict[str, Any]]) -> str:
-        parts: list[str] = []
+        """Create a readable summary string of all active warnings."""
+        parts = []
         for w in warnings:
-            module = str(w.get("module", "")).strip()
-            typ = str(w.get("type", "")).strip()
-            level = str(w.get("level", "")).strip()
-            info = str(w.get("info", "")).strip()
-
-            p = f"{module}:{typ}" if (module or typ) else "UNKNOWN"
-            if level:
-                p += f" ({level})"
-            if info:
-                p += f" - {info}"
+            m = str(w.get("module", "")).strip()
+            t = str(w.get("type", "")).strip()
+            l = str(w.get("level", "")).strip()
+            i = str(w.get("info", "")).strip()
+            p = f"{m}:{t}" if (m or t) else "UNKNOWN"
+            if l: p += f" ({l})"
+            if i: p += f" - {i}"
             parts.append(p)
         return "; ".join(parts)
 
     def _warnings_hash(self, warnings: list[dict[str, Any]]) -> str:
-        items = []
-        for w in warnings:
-            items.append(
-                (
-                    str(w.get("module", "")),
-                    str(w.get("type", "")),
-                    str(w.get("level", "")),
-                    str(w.get("info", "")),
-                )
-            )
+        """Generate a hash string to detect changes in warnings."""
+        items = [
+            (str(w.get("module", "")), str(w.get("type", "")), str(w.get("level", "")), str(w.get("info", ""))) 
+            for w in warnings
+        ]
         items.sort()
         return "|".join(["/".join(i) for i in items])
 
     def _count_warnings(self, alarm_obj: Any) -> int:
+        """Count the number of active warnings."""
         if not isinstance(alarm_obj, dict):
             return 0
         alarm_list = alarm_obj.get("alarm")
         if isinstance(alarm_list, list):
             return len(alarm_list)
-        keys = [k for k in alarm_obj.keys() if str(k).isdigit()]
-        return len(keys)
+        return len([k for k in alarm_obj.keys() if str(k).isdigit()])
 
     def _normalize_running_status(self, raw: Any) -> dict[str, Any]:
+        """Normalize the runningStatus response."""
         out: dict[str, Any] = {
-            "work_state_raw": None,
-            "task_id": None,
-            "cpu_temp": None,
-            "alarm_present": None,
-            "alarm_current": None,
-            "alarm_history": None,
-            "dev_time": None,
+            "work_state_raw": None, "task_id": None, "cpu_temp": None, 
+            "alarm_present": None, "alarm_current": None, "alarm_history": None, "dev_time": None
         }
-
         if not isinstance(raw, dict):
             return out
-
         data = raw.get("data") if isinstance(raw.get("data"), dict) else {}
         cur_mode = data.get("curMode") if isinstance(data.get("curMode"), dict) else {}
-
+        
         out["cpu_temp"] = data.get("cpuTemp")
         out["dev_time"] = data.get("devTime")
         out["work_state_raw"] = cur_mode.get("mode")
         out["task_id"] = cur_mode.get("taskId")
-
-        cur_alarm = data.get("curAlarmInfo")
-        alarm_hist = data.get("alarmInfo")
-
-        out["alarm_current"] = cur_alarm
-        out["alarm_history"] = alarm_hist
-
-        warnings = self._warnings_list(cur_alarm)
-        out["alarm_present"] = len(warnings) > 0
+        out["alarm_current"] = data.get("curAlarmInfo")
+        out["alarm_history"] = data.get("alarmInfo")
+        out["alarm_present"] = len(self._warnings_list(out["alarm_current"])) > 0
         return out
 
     def _normalize_gap(self, raw: Any) -> dict[str, Any]:
+        """Normalize lid/gap state."""
         lid_open = None
         if isinstance(raw, dict):
             data = raw.get("data") if isinstance(raw.get("data"), dict) else {}
-            state = str(data.get("state", "")).lower()
-            if state in {"on", "off"}:
-                lid_open = (state == "on")
+            if str(data.get("state", "")).lower() in {"on", "off"}:
+                lid_open = (str(data.get("state", "")).lower() == "off") # off means open for M1U
         return {"lid_open": lid_open}
 
     def _normalize_smoking_fan(self, raw: Any) -> dict[str, Any]:
-        fan_state = None
-        if isinstance(raw, dict):
-            data = raw.get("data") if isinstance(raw.get("data"), dict) else {}
-            s = str(data.get("state", "")).lower()
-            if s in {"on", "off"}:
-                fan_state = s
-        return {"fan_state": fan_state}
+        """Normalize exhaust fan state and connectivity."""
+        out = {"fan_state": None, "fan_exist": None}
+        if isinstance(raw, dict) and isinstance(raw.get("data"), dict):
+            data = raw.get("data", {})
+            if str(data.get("state", "")).lower() in {"on", "off"}:
+                out["fan_state"] = str(data.get("state", "")).lower()
+            if isinstance(data.get("exist"), bool):
+                out["fan_exist"] = data.get("exist")
+        return out
 
     def _normalize_ext_purifier(self, raw: Any) -> dict[str, Any]:
+        """Normalize external purifier state."""
         out = {
-            "ext_purifier_state": None,
-            "ext_purifier_exist": None,
-            "ext_purifier_power": None,
-            "ext_purifier_current": None,
+            "ext_purifier_state": None, "ext_purifier_exist": None, 
+            "ext_purifier_power": None, "ext_purifier_current": None
         }
         if isinstance(raw, dict) and isinstance(raw.get("data"), dict):
             data = raw["data"]
-            st = str(data.get("state", "")).lower()
-            if st in {"on", "off"}:
-                out["ext_purifier_state"] = st
-            exist = data.get("exist")
-            if isinstance(exist, bool):
-                out["ext_purifier_exist"] = exist
+            if str(data.get("state", "")).lower() in {"on", "off"}:
+                out["ext_purifier_state"] = str(data.get("state", "")).lower()
+            if isinstance(data.get("exist"), bool):
+                out["ext_purifier_exist"] = data.get("exist")
+            else:
+                out["ext_purifier_exist"] = (data.get("version", "{}") != "{}")
             out["ext_purifier_power"] = data.get("power")
             out["ext_purifier_current"] = data.get("current")
         return out
 
     def _normalize_machine_lock(self, raw: Any) -> dict[str, Any]:
+        """Normalize machine physical lock."""
         locked = None
         if isinstance(raw, dict) and isinstance(raw.get("data"), dict):
-            st = str(raw["data"].get("state", "")).lower()
-            if st in {"on", "off"}:
-                locked = (st == "on")
+            if str(raw["data"].get("state", "")).lower() in {"on", "off"}:
+                locked = (str(raw["data"].get("state", "")).lower() == "on")
         return {"machine_lock": locked}
 
     def _normalize_drawer(self, raw: Any) -> dict[str, Any]:
+        """Normalize bottom drawer state (Not applicable for M1 Ultra)."""
         drawer_open = None
         if isinstance(raw, dict) and isinstance(raw.get("data"), dict):
-            st = str(raw["data"].get("state", "")).lower()
-            if st in {"on", "off"}:
-                drawer_open = (st == "on")
+            if str(raw["data"].get("state", "")).lower() in {"on", "off"}:
+                drawer_open = (str(raw["data"].get("state", "")).lower() == "off")
         return {"drawer_open": drawer_open}
 
     def _normalize_airassist(self, raw: Any) -> dict[str, Any]:
+        """Normalize AirAssist connectivity and running state."""
         out = {
-            "airassist_state": None,
-            "airassist_power": None,
-            "airassist_version": None,
-            "airassist_fire_trigger": None,
+            "airassist_state": None, "airassist_exist": None, 
+            "airassist_power": None, "airassist_version": None, "airassist_fire_trigger": None
         }
         if isinstance(raw, dict) and isinstance(raw.get("data"), dict):
             data = raw["data"]
-            st = str(data.get("state", "")).lower()
-            if st in {"on", "off"}:
-                out["airassist_state"] = st
-            out["airassist_power"] = data.get("power")
-            out["airassist_version"] = data.get("version")
+            try: 
+                power = float(data.get("power", 0))
+            except (ValueError, TypeError): 
+                power = 0.0
+            
+            # The AirAssist is only actively blowing if power > 0
+            out["airassist_state"] = "on" if power > 0 else "off"
+            version = str(data.get("version", "")).strip()
+            out["airassist_exist"] = bool(version)
+            out["airassist_power"] = power
+            out["airassist_version"] = version
             out["airassist_fire_trigger"] = data.get("fireTiggerSta")
         return out
 
     def _fetch_data_sync(self) -> dict[str, Any]:
+        """Main polling function running in an executor job."""
         self._tick += 1
+        
+        # Load previous data to prevent sensors from becoming "Unavailable"
+        normalized: dict[str, Any] = {}
+        if self.data:
+            normalized = dict(self.data)
+        normalized["_unavailable"] = False
 
-        normalized: dict[str, Any] = {
-            "_unavailable": False,
-            "work_state_raw": None,
-            "task_id": None,
-            "cpu_temp": None,
-            "dev_time": None,
-            "alarm_present": None,
-            "warnings_count": 0,
-            "warnings_details": None,
-            "warnings_summary": None,
-            "warnings_hash": None,
-            "warnings_changed": None,
-            "alarm_current": None,
-            "alarm_history": None,
-            "lid_open": None,
-            "fan_state": None,
-            "ext_purifier_state": None,
-            "ext_purifier_exist": None,
-            "ext_purifier_power": None,
-            "ext_purifier_current": None,
-            "machine_lock": None,
-            "drawer_open": None,
-            "airassist_state": None,
-            "airassist_power": None,
-            "airassist_version": None,
-            "airassist_fire_trigger": None,
-            "machine_info": self._cached_machine_info,
-            "working_info": self._cached_working_info,
-            "config": self._cached_config,
-            "legacy": None,
-        }
-
+        # 1. Fetch runningStatus (Silent fetch, doesn't wake up the device)
         try:
             raw_run = self._get("/device/runningStatus")
             if _is_invalid_or_not_supported(raw_run):
                 raise RuntimeError("v2 runningStatus not supported")
-
             normalized.update(self._normalize_running_status(raw_run))
             self._log_reachability(True)
-
         except requests.exceptions.ConnectionError as err:
             self._log_reachability(False)
-            _LOGGER.debug("XTool %s connection error: %s", self.ip_address, err)
-            return {"_unavailable": True}
-
+            normalized["_unavailable"] = True
+            return normalized
         except Exception:
+            # Fallback for older legacy devices
             try:
                 raw_status = self._get("/status")
                 if _is_invalid_or_not_supported(raw_status):
                     raise RuntimeError("legacy /status not supported")
-
                 normalized["legacy"] = raw_status
-
                 if isinstance(raw_status, dict):
                     if "STATUS" in raw_status:
                         normalized["work_state_raw"] = str(raw_status.get("STATUS") or "").strip()
                     elif "mode" in raw_status:
                         normalized["work_state_raw"] = str(raw_status.get("mode") or "").strip()
-
                     if "CPU_TEMP" in raw_status:
                         normalized["cpu_temp"] = raw_status.get("CPU_TEMP")
-
                 self._log_reachability(True)
-
-            except requests.exceptions.ConnectionError as err2:
+            except Exception:
                 self._log_reachability(False)
-                _LOGGER.debug("XTool %s connection error (fallback): %s", self.ip_address, err2)
-                return {"_unavailable": True}
-            except Exception as err2:  # noqa: BLE001
-                self._log_reachability(False)
-                _LOGGER.debug("XTool %s update failed: %s", self.ip_address, err2)
-                return {"_unavailable": True}
+                normalized["_unavailable"] = True
+                return normalized
 
+        # Check if the machine is in sleep mode
+        mode = str(normalized.get("work_state_raw") or "").upper()
+        is_sleeping = "SLEEP" in mode or "STANDBY" in mode
+
+        # Process Warnings
         normalized["warnings_count"] = self._count_warnings(normalized.get("alarm_current"))
         warnings = self._warnings_list(normalized.get("alarm_current"))
         normalized["warnings_details"] = warnings
         normalized["warnings_summary"] = self._warnings_summary(warnings)
-
         h = self._warnings_hash(warnings)
         normalized["warnings_hash"] = h
-        normalized["warnings_changed"] = (
-            self._warnings_hash_last is not None and h != self._warnings_hash_last
-        )
+        normalized["warnings_changed"] = (self._warnings_hash_last is not None and h != self._warnings_hash_last)
         self._warnings_hash_last = h
 
-        # fast best-effort peripherals
-        for path, normalizer in (
-            ("/peripheral/gap", self._normalize_gap),
-            ("/peripheral/smoking_fan", self._normalize_smoking_fan),
-            ("/peripheral/ext_purifier", self._normalize_ext_purifier),
-            ("/peripheral/machine_lock", self._normalize_machine_lock),
-            ("/peripheral/drawer", self._normalize_drawer),
-            ("/peripheral/airassist", self._normalize_airassist),
-        ):
-            try:
-                raw = self._get(path)
-                if not _is_invalid_or_not_supported(raw):
-                    normalized.update(normalizer(raw))
-            except Exception:
-                pass
+        # 2. Fetch peripherals ONLY if the machine is currently awake
+        if not is_sleeping:
+            
+            # Prepare the list of endpoints to poll
+            peripherals = [
+                ("/peripheral/gap", self._normalize_gap),
+                ("/peripheral/smoking_fan", self._normalize_smoking_fan),
+                ("/peripheral/ext_purifier", self._normalize_ext_purifier),
+                ("/peripheral/machine_lock", self._normalize_machine_lock),
+                ("/peripheral/airassist", self._normalize_airassist),
+            ]
+            
+            # The M1 Ultra does not have a drawer, skip polling it to save requests
+            if self.device_type not in ("m1u", "m1 ultra"):
+                peripherals.append(("/peripheral/drawer", self._normalize_drawer))
 
-        # slow extras: do on first tick AND then periodically
-        if self._tick == 1 or (self._tick % self._slow_every) == 0:
-            try:
-                mi = self._get("/device/machineInfo")
-                if not _is_invalid_or_not_supported(mi) and isinstance(mi, dict):
-                    self._cached_machine_info = mi
-                    normalized["machine_info"] = mi
-            except Exception:
-                pass
+            for path, normalizer in peripherals:
+                try:
+                    raw = self._get(path)
+                    if not _is_invalid_or_not_supported(raw):
+                        normalized.update(normalizer(raw))
+                except Exception:
+                    pass
 
-            try:
-                wi = self._get("/device/workingInfo")
-                if not _is_invalid_or_not_supported(wi) and isinstance(wi, dict):
-                    self._cached_working_info = wi
-                    normalized["working_info"] = wi
-            except Exception:
-                pass
+            # 3. M1 Ultra specific POST requests (Carriages, Hatch, Knifes)
+            if self.device_type in ("m1u", "m1 ultra"):
+                try:
+                    raw_hatch = self._get("/peripheral/heighten")
+                    if isinstance(raw_hatch, dict) and isinstance(raw_hatch.get("data"), dict):
+                        door = str(raw_hatch["data"].get("door", "")).lower()
+                        if door in ("on", "off"):
+                            normalized["hatch_open"] = (door == "off")
+                except Exception:
+                    pass
 
-            try:
-                cfg = self._post(
-                    "/config/get",
-                    {
-                        "alias": "config",
-                        "type": "user",
-                        "kv": ["beepEnable", "fillLightBrightness", "purifierTimeout", "taskId", "workingMode"],
-                    },
-                )
-                if not _is_invalid_or_not_supported(cfg) and isinstance(cfg, dict):
-                    self._cached_config = cfg
-                    normalized["config"] = cfg
-            except Exception:
-                pass
+                try:
+                    raw_wh = self._post("/peripheral/workhead_ID", {"action": "get"})
+                    if isinstance(raw_wh, dict) and isinstance(raw_wh.get("data"), dict):
+                        normalized["workhead_drived"] = raw_wh["data"].get("drived")
+                        normalized["workhead_driving"] = raw_wh["data"].get("driving")
+                except Exception:
+                    pass
+
+                try:
+                    # Retrieves the currently detected knife (requires physical sync first)
+                    raw_knife = self._post("/peripheral/knife_head", {"action": "get"})
+                    if isinstance(raw_knife, dict) and isinstance(raw_knife.get("data"), dict):
+                        normalized["knife_driving"] = raw_knife["data"].get("driving")
+                except Exception:
+                    pass
+
+                try:
+                    raw_ink = self._post("/peripheral/inkjet_printer", {"action": "get"})
+                    if isinstance(raw_ink, dict) and isinstance(raw_ink.get("data"), dict):
+                        normalized["inkjet_exist"] = raw_ink["data"].get("exist")
+                except Exception:
+                    pass
+
+            # 4. Slow polling endpoints (Machine Info, Config)
+            if self._tick == 1 or (self._tick % self._slow_every) == 0:
+                try:
+                    mi = self._get("/device/machineInfo")
+                    if not _is_invalid_or_not_supported(mi) and isinstance(mi, dict):
+                        self._cached_machine_info = mi
+                        normalized["machine_info"] = mi
+                except Exception:
+                    pass
+                
+                try:
+                    wi = self._get("/device/workingInfo")
+                    if not _is_invalid_or_not_supported(wi) and isinstance(wi, dict):
+                        self._cached_working_info = wi
+                        normalized["working_info"] = wi
+                except Exception:
+                    pass
+                
+                try:
+                    cfg = self._post(
+                        "/config/get", 
+                        {"alias": "config", "type": "user", "kv": ["beepEnable", "workingMode"]}
+                    )
+                    if not _is_invalid_or_not_supported(cfg) and isinstance(cfg, dict):
+                        self._cached_config = cfg
+                        normalized["config"] = cfg
+                except Exception:
+                    pass
 
         return normalized
 
     def _log_reachability(self, reachable: bool) -> None:
+        """Log online/offline status changes."""
         if self._reachable_last is None:
             self._reachable_last = reachable
             return
@@ -395,10 +372,10 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up the XTool integration from a config entry."""
     ip = entry.data[CONF_IP_ADDRESS]
     dev_type = entry.data[CONF_DEVICE_TYPE].lower()
 
-    # ✅ D1 uses a different API stack
     if dev_type == "d1":
         coordinator: DataUpdateCoordinator = XToolD1Coordinator(hass, ip)
         await coordinator.async_config_entry_first_refresh()
@@ -419,6 +396,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
         hass.data[DOMAIN].pop(entry.entry_id, None)

--- a/custom_components/xtool/binary_sensor.py
+++ b/custom_components/xtool/binary_sensor.py
@@ -10,12 +10,12 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN, MANUFACTURER
 
-
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
+    """Set up the binary sensor entities."""
     store = hass.data[DOMAIN][entry.entry_id]
     coordinator = store["coordinator"]
     name: str = store["name"]
@@ -23,16 +23,13 @@ async def async_setup_entry(
     device_type: str = store.get("device_type", "").lower()
 
     d = coordinator.data or {}
-
     entities: list[BinarySensorEntity] = []
 
     if device_type == "d1":
-        entities += [
+        entities.extend([
             D1PowerBinarySensor(coordinator, name, entry_id, device_type),
             D1RunningBinarySensor(coordinator, name, entry_id, device_type),
-        ]
-
-        # Optional flags (only if present)
+        ])
         if d.get("tiltStopFlag") is not None:
             entities.append(D1FlagBinarySensor(coordinator, name, entry_id, device_type, "tiltStopFlag", "Tilt Stop", BinarySensorDeviceClass.PROBLEM))
         if d.get("limitStopFlag") is not None:
@@ -41,28 +38,38 @@ async def async_setup_entry(
             entities.append(D1FlagBinarySensor(coordinator, name, entry_id, device_type, "movingStopFlag", "Moving Stop", BinarySensorDeviceClass.PROBLEM))
         if d.get("sdCard") is not None:
             entities.append(D1FlagBinarySensor(coordinator, name, entry_id, device_type, "sdCard", "SD Card", BinarySensorDeviceClass.CONNECTIVITY))
-
+        
         async_add_entities(entities, True)
         return
 
-    # ---- P2/F1/M1 stack (existing)
-    entities += [
+    # Standard entities for P2, F1, M1, M1 Ultra
+    entities.extend([
         XToolPowerBinarySensor(coordinator, name, entry_id, device_type),
         XToolAlarmBinarySensor(coordinator, name, entry_id, device_type),
         XToolRunningBinarySensor(coordinator, name, entry_id, device_type),
-    ]
+        XToolLidOpenBinarySensor(coordinator, name, entry_id, device_type),
+        XToolMachineLockBinarySensor(coordinator, name, entry_id, device_type),
+    ])
 
-    if d.get("lid_open") is not None:
-        entities.append(XToolLidOpenBinarySensor(coordinator, name, entry_id, device_type))
-    if d.get("machine_lock") is not None:
-        entities.append(XToolMachineLockBinarySensor(coordinator, name, entry_id, device_type))
-    if d.get("drawer_open") is not None:
+    # The M1 Ultra does not have a drawer, so we exclude it here
+    if device_type not in ("m1u", "m1 ultra"):
         entities.append(XToolDrawerOpenBinarySensor(coordinator, name, entry_id, device_type))
+
+    # M1 Ultra specific accessory sensors
+    if device_type in ("m1u", "m1 ultra"):
+        entities.extend([
+            XToolAirAssistConnectedBinarySensor(coordinator, name, entry_id, device_type),
+            XToolFanConnectedBinarySensor(coordinator, name, entry_id, device_type),
+            XToolExtPurifierConnectedBinarySensor(coordinator, name, entry_id, device_type),
+            XToolHatchBinarySensor(coordinator, name, entry_id, device_type),
+            XToolInkModuleCableBinarySensor(coordinator, name, entry_id, device_type),
+        ])
 
     async_add_entities(entities, True)
 
 
 class _BaseBinary(CoordinatorEntity, BinarySensorEntity):
+    """Base class for xTool binary sensors."""
     _attr_has_entity_name = True
 
     def __init__(self, coordinator, name: str, entry_id: str, device_type: str) -> None:
@@ -86,177 +93,189 @@ class _BaseBinary(CoordinatorEntity, BinarySensorEntity):
     def _unavailable(self) -> bool:
         return bool(self._data().get("_unavailable"))
 
-
-# ----------------
-# D1 entities
-# ----------------
+# --- D1 ---
 class D1PowerBinarySensor(_BaseBinary):
     _attr_device_class = BinarySensorDeviceClass.POWER
-
     def __init__(self, coordinator, name: str, entry_id: str, device_type: str) -> None:
         super().__init__(coordinator, name, entry_id, device_type)
         self._attr_name = "Power"
         self._attr_unique_id = f"{entry_id}_d1_power"
-
     @property
     def is_on(self) -> bool:
         return (not self._unavailable()) and bool(self.coordinator.last_update_success)
 
-
 class D1RunningBinarySensor(_BaseBinary):
     _attr_device_class = BinarySensorDeviceClass.RUNNING
-
     def __init__(self, coordinator, name: str, entry_id: str, device_type: str) -> None:
         super().__init__(coordinator, name, entry_id, device_type)
         self._attr_name = "Running"
         self._attr_unique_id = f"{entry_id}_d1_running"
-
     @property
     def is_on(self) -> bool:
         return str(self._data().get("working_state") or "").lower() == "running"
 
-
 class D1FlagBinarySensor(_BaseBinary):
-    def __init__(
-        self,
-        coordinator,
-        name: str,
-        entry_id: str,
-        device_type: str,
-        key: str,
-        label: str,
-        device_class: BinarySensorDeviceClass | None,
-    ) -> None:
+    def __init__(self, coordinator, name: str, entry_id: str, device_type: str, key: str, label: str, device_class: BinarySensorDeviceClass | None) -> None:
         super().__init__(coordinator, name, entry_id, device_type)
         self._key = key
         self._attr_name = label
         self._attr_unique_id = f"{entry_id}_d1_{key}"
         self._attr_device_class = device_class
-
     @property
     def available(self) -> bool:
-        if self._unavailable():
-            return False
+        if self._unavailable(): return False
         return self._data().get(self._key) is not None
-
     @property
     def is_on(self) -> bool:
         return bool(self._data().get(self._key))
 
-
-# -----------------------------
-# P2/F1/M1 entities (existing)
-# -----------------------------
+# --- P2/F1/M1 ---
 class XToolPowerBinarySensor(_BaseBinary):
     _attr_device_class = BinarySensorDeviceClass.POWER
-
     def __init__(self, coordinator, name: str, entry_id: str, device_type: str) -> None:
         super().__init__(coordinator, name, entry_id, device_type)
         self._attr_name = "Power"
         self._attr_unique_id = f"{entry_id}_power"
-
     @property
     def is_on(self) -> bool:
         return (not self._unavailable()) and bool(self.coordinator.last_update_success)
 
-
 class XToolAlarmBinarySensor(_BaseBinary):
     _attr_device_class = BinarySensorDeviceClass.PROBLEM
-
     def __init__(self, coordinator, name: str, entry_id: str, device_type: str) -> None:
         super().__init__(coordinator, name, entry_id, device_type)
         self._attr_name = "Alarm"
         self._attr_unique_id = f"{entry_id}_alarm"
-
     @property
     def available(self) -> bool:
-        if self._unavailable():
-            return False
-        return self._data().get("alarm_present") is not None
-
+        return not self._unavailable()
     @property
     def is_on(self) -> bool:
         return bool(self._data().get("alarm_present"))
 
-    @property
-    def extra_state_attributes(self) -> dict[str, Any]:
-        d = self._data()
-        return {
-            "warnings_count": d.get("warnings_count"),
-            "warnings_summary": d.get("warnings_summary"),
-            "warnings_changed": d.get("warnings_changed"),
-            "warnings_hash": d.get("warnings_hash"),
-            "task_id": d.get("task_id"),
-            "alarm_current": d.get("alarm_current"),
-        }
-
-
 class XToolRunningBinarySensor(_BaseBinary):
     _attr_device_class = BinarySensorDeviceClass.RUNNING
-
     def __init__(self, coordinator, name: str, entry_id: str, device_type: str) -> None:
         super().__init__(coordinator, name, entry_id, device_type)
         self._attr_name = "Running"
         self._attr_unique_id = f"{entry_id}_running"
-
+    @property
+    def available(self) -> bool:
+        return not self._unavailable()
     @property
     def is_on(self) -> bool:
         raw = str(self._data().get("work_state_raw") or "").upper()
         return raw in {"WORK", "P_WORKING", "P_WORK", "P_MEASURE"}
 
-
 class XToolLidOpenBinarySensor(_BaseBinary):
     _attr_device_class = BinarySensorDeviceClass.OPENING
-
     def __init__(self, coordinator, name: str, entry_id: str, device_type: str) -> None:
         super().__init__(coordinator, name, entry_id, device_type)
-        self._attr_name = "Lid Open"
+        self._attr_name = "Lid"
         self._attr_unique_id = f"{entry_id}_lid_open"
-
     @property
     def available(self) -> bool:
-        if self._unavailable():
-            return False
+        if self._unavailable(): return False
         return self._data().get("lid_open") is not None
-
     @property
     def is_on(self) -> bool:
         return bool(self._data().get("lid_open"))
 
-
 class XToolMachineLockBinarySensor(_BaseBinary):
     _attr_device_class = BinarySensorDeviceClass.LOCK
-
     def __init__(self, coordinator, name: str, entry_id: str, device_type: str) -> None:
         super().__init__(coordinator, name, entry_id, device_type)
         self._attr_name = "Machine Lock"
         self._attr_unique_id = f"{entry_id}_machine_lock"
-
     @property
     def available(self) -> bool:
-        if self._unavailable():
-            return False
+        if self._unavailable(): return False
         return self._data().get("machine_lock") is not None
-
     @property
     def is_on(self) -> bool:
         return bool(self._data().get("machine_lock"))
 
-
 class XToolDrawerOpenBinarySensor(_BaseBinary):
     _attr_device_class = BinarySensorDeviceClass.OPENING
-
     def __init__(self, coordinator, name: str, entry_id: str, device_type: str) -> None:
         super().__init__(coordinator, name, entry_id, device_type)
         self._attr_name = "Drawer Open"
         self._attr_unique_id = f"{entry_id}_drawer_open"
-
     @property
     def available(self) -> bool:
-        if self._unavailable():
-            return False
+        if self._unavailable(): return False
         return self._data().get("drawer_open") is not None
-
     @property
     def is_on(self) -> bool:
         return bool(self._data().get("drawer_open"))
+
+# --- M1 Ultra Accessory Sensors ---
+class XToolHatchBinarySensor(_BaseBinary):
+    _attr_device_class = BinarySensorDeviceClass.OPENING
+    def __init__(self, coordinator, name: str, entry_id: str, device_type: str) -> None:
+        super().__init__(coordinator, name, entry_id, device_type)
+        self._attr_name = "Hatch"
+        self._attr_unique_id = f"{entry_id}_hatch"
+    @property
+    def available(self) -> bool:
+        if self._unavailable(): return False
+        return self._data().get("hatch_open") is not None
+    @property
+    def is_on(self) -> bool:
+        return bool(self._data().get("hatch_open"))
+
+class XToolAirAssistConnectedBinarySensor(_BaseBinary):
+    _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
+    def __init__(self, coordinator, name: str, entry_id: str, device_type: str) -> None:
+        super().__init__(coordinator, name, entry_id, device_type)
+        self._attr_name = "AirAssist Connected"
+        self._attr_unique_id = f"{entry_id}_airassist_connected"
+    @property
+    def available(self) -> bool:
+        if self._unavailable(): return False
+        return self._data().get("airassist_exist") is not None
+    @property
+    def is_on(self) -> bool:
+        return bool(self._data().get("airassist_exist"))
+
+class XToolFanConnectedBinarySensor(_BaseBinary):
+    _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
+    def __init__(self, coordinator, name: str, entry_id: str, device_type: str) -> None:
+        super().__init__(coordinator, name, entry_id, device_type)
+        self._attr_name = "Exhaust Fan Connected"
+        self._attr_unique_id = f"{entry_id}_fan_connected"
+    @property
+    def available(self) -> bool:
+        if self._unavailable(): return False
+        return self._data().get("fan_exist") is not None
+    @property
+    def is_on(self) -> bool:
+        return bool(self._data().get("fan_exist"))
+
+class XToolExtPurifierConnectedBinarySensor(_BaseBinary):
+    _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
+    def __init__(self, coordinator, name: str, entry_id: str, device_type: str) -> None:
+        super().__init__(coordinator, name, entry_id, device_type)
+        self._attr_name = "External Purifier Connected"
+        self._attr_unique_id = f"{entry_id}_ext_purifier_connected"
+    @property
+    def available(self) -> bool:
+        if self._unavailable(): return False
+        return self._data().get("ext_purifier_exist") is not None
+    @property
+    def is_on(self) -> bool:
+        return bool(self._data().get("ext_purifier_exist"))
+
+class XToolInkModuleCableBinarySensor(_BaseBinary):
+    _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
+    def __init__(self, coordinator, name: str, entry_id: str, device_type: str) -> None:
+        super().__init__(coordinator, name, entry_id, device_type)
+        self._attr_name = "Ink Module Cable"
+        self._attr_unique_id = f"{entry_id}_ink_cable"
+    @property
+    def available(self) -> bool:
+        if self._unavailable(): return False
+        return self._data().get("inkjet_exist") is not None
+    @property
+    def is_on(self) -> bool:
+        return bool(self._data().get("inkjet_exist"))

--- a/custom_components/xtool/button.py
+++ b/custom_components/xtool/button.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN, MANUFACTURER
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the button entities."""
+    store = hass.data[DOMAIN][entry.entry_id]
+    coordinator = store["coordinator"]
+    name: str = store["name"]
+    entry_id: str = store["entry_id"]
+    device_type: str = store.get("device_type", "").lower()
+
+    # Only add the Sync button for the M1 Ultra
+    if device_type in ("m1u", "m1 ultra"):
+        async_add_entities([XToolSyncKnifeButton(coordinator, name, entry_id, device_type)])
+
+
+class XToolSyncKnifeButton(CoordinatorEntity, ButtonEntity):
+    """Button to sync/spin the knife module for detection."""
+    _attr_has_entity_name = True
+    _attr_icon = "mdi:sync"
+
+    def __init__(self, coordinator, name: str, entry_id: str, device_type: str) -> None:
+        super().__init__(coordinator)
+        self._device_name = name
+        self._entry_id = entry_id
+        self._device_type = device_type
+        self._attr_name = "Sync Knife Module"
+        self._attr_unique_id = f"{entry_id}_sync_knife"
+
+    @property
+    def device_info(self) -> dict[str, Any]:
+        """Return device information."""
+        return {
+            "identifiers": {(DOMAIN, self._entry_id)},
+            "name": self._device_name,
+            "manufacturer": MANUFACTURER,
+            "model": self._device_type.upper(),
+        }
+
+    @property
+    def available(self) -> bool:
+        """The button is only available when the Knife holder (ID 29) is inserted."""
+        data = self.coordinator.data or {}
+        if data.get("_unavailable"):
+            return False
+        
+        # Check if the currently attached tool is the Knife Holder
+        workhead = data.get("workhead_driving")
+        if workhead is None:
+            return False
+        
+        try:
+            return int(workhead) == 29
+        except (ValueError, TypeError):
+            return False
+
+    async def async_press(self) -> None:
+        """Trigger the knife sync action."""
+        # Send the get_sync command to spin and identify the specific knife blade
+        await self.coordinator.hass.async_add_executor_job(
+            self.coordinator._post, "/peripheral/knife_head", {"action": "get_sync"}
+        )
+        # Force a refresh to update the sensor immediately after syncing
+        await self.coordinator.async_request_refresh()

--- a/custom_components/xtool/const.py
+++ b/custom_components/xtool/const.py
@@ -1,10 +1,13 @@
+# Constants for the xTool integration
 DOMAIN = "xtool"
 
-PLATFORMS: list[str] = ["sensor", "binary_sensor", "camera"]
+# Supported Home Assistant platforms
+PLATFORMS: list[str] = ["sensor", "binary_sensor", "camera", "switch", "button"]
 
 CONF_IP_ADDRESS = "ip_address"
 CONF_DEVICE_TYPE = "device_type"
 
+# Mapping of display names to internal device type codes
 SUPPORTED_DEVICE_TYPES: dict[str, str] = {
     "P2": "p2",
     "P3": "p3",
@@ -20,7 +23,7 @@ SUPPORTED_DEVICE_TYPES: dict[str, str] = {
 
 MANUFACTURER = "xTool"
 
-# Polling:
-DEFAULT_UPDATE_INTERVAL = 10          # seconds
-DEFAULT_SLOW_UPDATE_INTERVAL = 120    # seconds
+# Update intervals for polling
+DEFAULT_UPDATE_INTERVAL = 10          # Fast update interval in seconds
+DEFAULT_SLOW_UPDATE_INTERVAL = 120    # Slow update interval (e.g. for static settings)
 HTTP_TIMEOUT = 5

--- a/custom_components/xtool/sensor.py
+++ b/custom_components/xtool/sensor.py
@@ -11,59 +11,64 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN, MANUFACTURER
 
-
 async def async_setup_entry(
-    hass: HomeAssistant,
-    entry: ConfigEntry,
-    async_add_entities: AddEntitiesCallback,
+    hass: HomeAssistant, 
+    entry: ConfigEntry, 
+    async_add_entities: AddEntitiesCallback
 ) -> None:
+    """Set up the sensor entities."""
     store = hass.data[DOMAIN][entry.entry_id]
     coordinator = store["coordinator"]
     name: str = store["name"]
     entry_id: str = store["entry_id"]
     device_type: str = store.get("device_type", "").lower()
 
-    d = coordinator.data or {}
-
     entities: list[SensorEntity] = []
 
     if device_type == "d1":
-        entities += [
+        entities.extend([
             D1StatusSensor(coordinator, name, entry_id, device_type),
             D1ProgressSensor(coordinator, name, entry_id, device_type),
             D1WorkingTimeSensor(coordinator, name, entry_id, device_type),
             D1LineSensor(coordinator, name, entry_id, device_type),
             D1MachineTypeSensor(coordinator, name, entry_id, device_type),
-        ]
+        ])
         async_add_entities(entities, True)
         return
 
-    # ---- P2/F1/M1 existing sensor set (minimal)
-    entities += [
+    entities.extend([
         XToolWorkStateSensor(coordinator, name, entry_id, device_type),
         XToolCpuTempSensor(coordinator, name, entry_id, device_type),
         XToolWarningsCountSensor(coordinator, name, entry_id, device_type),
         XToolJobsSensor(coordinator, name, entry_id, device_type),
         XToolSystemRuntimeSensor(coordinator, name, entry_id, device_type),
-    ]
+    ])
 
-    if d.get("fan_state") is not None:
-        entities.append(XToolFanStateSensor(coordinator, name, entry_id, device_type))
-    if d.get("ext_purifier_state") is not None or d.get("ext_purifier_exist") is not None:
-        entities.append(XToolExtPurifierStateSensor(coordinator, name, entry_id, device_type))
-    if d.get("airassist_state") is not None or d.get("airassist_version") is not None:
-        entities.append(XToolAirAssistSensor(coordinator, name, entry_id, device_type))
+    if device_type != "d1":
+        entities.extend([
+            XToolFanStateSensor(coordinator, name, entry_id, device_type),
+            XToolExtPurifierStateSensor(coordinator, name, entry_id, device_type),
+            XToolAirAssistSensor(coordinator, name, entry_id, device_type),
+        ])
 
     if device_type == "m1":
-        entities += [
+        entities.extend([
             XToolLegacyWaterTempSensor(coordinator, name, entry_id, device_type),
             XToolLegacyPurifierSensor(coordinator, name, entry_id, device_type),
-        ]
+        ])
+
+    if device_type in ("m1u", "m1 ultra"):
+        entities.extend([
+            XToolBasicCarriageSensor(coordinator, name, entry_id, device_type),
+            XToolMultiFunctionCarriageSensor(coordinator, name, entry_id, device_type),
+            XToolMultiFunctionModuleSensor(coordinator, name, entry_id, device_type),
+        ])
 
     async_add_entities(entities, True)
 
 
 class _BaseSensor(CoordinatorEntity, SensorEntity):
+    """Base class for xTool sensors."""
     _attr_has_entity_name = True
 
     def __init__(self, coordinator, name: str, entry_id: str, device_type: str) -> None:
@@ -87,377 +92,317 @@ class _BaseSensor(CoordinatorEntity, SensorEntity):
     def _unavailable(self) -> bool:
         return bool(self._data().get("_unavailable"))
 
-
-# ----------------
-# D1 Sensors
-# ----------------
+# --- D1 ---
 class D1StatusSensor(_BaseSensor):
     _attr_icon = "mdi:laser-pointer"
-
     def __init__(self, coordinator, name: str, entry_id: str, device_type: str) -> None:
         super().__init__(coordinator, name, entry_id, device_type)
         self._attr_name = "Status"
         self._attr_unique_id = f"{entry_id}_d1_status"
-
     @property
     def native_value(self) -> str:
-        if self._unavailable():
-            return "Unavailable"
+        if self._unavailable(): return "Unavailable"
         return str(self._data().get("working_state") or "Unknown")
-
 
 class D1ProgressSensor(_BaseSensor):
     _attr_icon = "mdi:progress-clock"
     _attr_native_unit_of_measurement = PERCENTAGE
     _attr_state_class = SensorStateClass.MEASUREMENT
-
     def __init__(self, coordinator, name: str, entry_id: str, device_type: str) -> None:
         super().__init__(coordinator, name, entry_id, device_type)
         self._attr_name = "Progress"
         self._attr_unique_id = f"{entry_id}_d1_progress"
-
     @property
     def native_value(self) -> Any:
-        if self._unavailable():
-            return None
+        if self._unavailable(): return None
         return self._data().get("progress_pct")
-
 
 class D1WorkingTimeSensor(_BaseSensor):
     _attr_icon = "mdi:timer-outline"
     _attr_native_unit_of_measurement = UnitOfTime.HOURS
     _attr_state_class = SensorStateClass.TOTAL_INCREASING
-
     def __init__(self, coordinator, name: str, entry_id: str, device_type: str) -> None:
         super().__init__(coordinator, name, entry_id, device_type)
         self._attr_name = "Working Time"
         self._attr_unique_id = f"{entry_id}_d1_working_time"
-
     @property
     def native_value(self) -> Any:
-        if self._unavailable():
-            return None
+        if self._unavailable(): return None
         s = self._data().get("working_s")
-        if s is None:
-            return None
-        return round(float(s) / 3600.0, 2)
-
-    @property
-    def extra_state_attributes(self) -> dict[str, Any]:
-        s = self._data().get("working_s")
-        if s is None:
-            return {}
-        hours = float(s) / 3600.0
-        return {"seconds": s, "days": round(hours / 24.0, 2)}
-
+        return round(float(s) / 3600.0, 2) if s is not None else None
 
 class D1LineSensor(_BaseSensor):
     _attr_icon = "mdi:format-list-numbered"
     _attr_state_class = SensorStateClass.MEASUREMENT
-
     def __init__(self, coordinator, name: str, entry_id: str, device_type: str) -> None:
         super().__init__(coordinator, name, entry_id, device_type)
         self._attr_name = "Line"
         self._attr_unique_id = f"{entry_id}_d1_line"
-
     @property
     def native_value(self) -> Any:
-        if self._unavailable():
-            return None
+        if self._unavailable(): return None
         return self._data().get("line")
-
 
 class D1MachineTypeSensor(_BaseSensor):
     _attr_icon = "mdi:information-outline"
-
     def __init__(self, coordinator, name: str, entry_id: str, device_type: str) -> None:
         super().__init__(coordinator, name, entry_id, device_type)
         self._attr_name = "Machine Type"
         self._attr_unique_id = f"{entry_id}_d1_machine_type"
-
     @property
     def native_value(self) -> Any:
-        if self._unavailable():
-            return None
+        if self._unavailable(): return None
         return self._data().get("machine_type")
 
-
-# -----------------------------
-# P2/F1/M1 Sensors (existing)
-# -----------------------------
+# --- P2/F1/M1 ---
 class XToolWorkStateSensor(_BaseSensor):
     _attr_icon = "mdi:laser-pointer"
-
     def __init__(self, coordinator, name: str, entry_id: str, device_type: str) -> None:
         super().__init__(coordinator, name, entry_id, device_type)
         self._attr_name = "Status"
         self._attr_unique_id = f"{entry_id}_status"
-
     def _map_mode(self, mode: str) -> str:
         mapping = {
-            "P_ERROR": "Error",
-            "WORK": "Running",
-            "P_WORK": "Running",
-            "P_WORKING": "Running",
-            "P_WORK_DONE": "Done",
-            "P_FINISH": "Done",
-            "P_IDLE": "Idle",
-            "P_SLEEP": "Sleep",
-            "P_ONLINE_READY_WORK": "Ready",
-            "P_OFFLINE_READY_WORK": "Ready",
-            "P_READY": "Ready",
-            "P_MEASURE": "Measuring",
+            "P_ERROR": "Error", "WORK": "Running", "P_WORK": "Running", 
+            "P_WORKING": "Running", "P_WORK_DONE": "Done", "P_FINISH": "Done", 
+            "P_IDLE": "Idle", "P_SLEEP": "Sleep", "P_ONLINE_READY_WORK": "Ready", 
+            "P_OFFLINE_READY_WORK": "Ready", "P_READY": "Ready", "P_MEASURE": "Measuring"
         }
         return mapping.get(mode, "Unknown")
-
     def _map_status(self, status: str) -> str:
         mapping = {
-            "P_ONLINE_READY_WORK": "Ready",
-            "P_OFFLINE_READY_WORK": "Ready",
-            "P_WORK_DONE": "Done",
-            "P_IDLE": "Idle",
-            "P_SLEEP": "Sleep",
-            "P_MEASURE": "Measuring",
-            "P_ERROR": "Error",
+            "P_ONLINE_READY_WORK": "Ready", "P_OFFLINE_READY_WORK": "Ready", 
+            "P_WORK_DONE": "Done", "P_IDLE": "Idle", "P_SLEEP": "Sleep", 
+            "P_MEASURE": "Measuring", "P_ERROR": "Error"
         }
         return mapping.get(status, self._map_mode(status))
-
     @property
     def native_value(self) -> str:
         d = self._data()
-        if d.get("_unavailable"):
-            return "Unavailable"
-
+        if d.get("_unavailable"): return "Unavailable"
         if self._device_type == "m1":
             legacy = d.get("legacy") if isinstance(d.get("legacy"), dict) else {}
             status = str(legacy.get("STATUS", "")).strip().upper()
-            if status:
-                return self._map_status(status)
-            raw = str(d.get("work_state_raw") or "").strip().upper()
-            return self._map_mode(raw) if raw else "Unknown"
-
+            if status: return self._map_status(status)
         raw = str(d.get("work_state_raw") or "").strip().upper()
         return self._map_mode(raw) if raw else "Unknown"
-
-    @property
-    def extra_state_attributes(self) -> dict[str, Any]:
-        d = self._data()
-        return {
-            "work_state_raw": d.get("work_state_raw"),
-            "task_id": d.get("task_id"),
-            "warnings_count": d.get("warnings_count"),
-            "warnings_summary": d.get("warnings_summary"),
-        }
-
 
 class XToolCpuTempSensor(_BaseSensor):
     _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_icon = "mdi:thermometer"
-
     def __init__(self, coordinator, name: str, entry_id: str, device_type: str) -> None:
         super().__init__(coordinator, name, entry_id, device_type)
         self._attr_name = "CPU Temp"
         self._attr_unique_id = f"{entry_id}_cpu_temp"
-
     @property
     def native_value(self) -> Any:
         d = self._data()
-        if self._unavailable():
-            return None
-        if d.get("cpu_temp") is not None:
-            return d.get("cpu_temp")
+        if self._unavailable(): return None
+        if d.get("cpu_temp") is not None: return d.get("cpu_temp")
         legacy = d.get("legacy") if isinstance(d.get("legacy"), dict) else {}
         return legacy.get("CPU_TEMP")
-
 
 class XToolWarningsCountSensor(_BaseSensor):
     _attr_icon = "mdi:alert"
     _attr_state_class = SensorStateClass.MEASUREMENT
-
     def __init__(self, coordinator, name: str, entry_id: str, device_type: str) -> None:
         super().__init__(coordinator, name, entry_id, device_type)
         self._attr_name = "Warnings"
         self._attr_unique_id = f"{entry_id}_warnings"
-
     @property
     def native_value(self) -> Any:
-        if self._unavailable():
-            return None
+        if self._unavailable(): return None
         return self._data().get("warnings_count")
-
-    @property
-    def extra_state_attributes(self) -> dict[str, Any]:
-        d = self._data()
-        return {
-            "warnings_summary": d.get("warnings_summary"),
-            "warnings_details": d.get("warnings_details"),
-            "warnings_changed": d.get("warnings_changed"),
-            "warnings_hash": d.get("warnings_hash"),
-        }
-
 
 class XToolJobsSensor(_BaseSensor):
     _attr_icon = "mdi:counter"
     _attr_state_class = SensorStateClass.TOTAL_INCREASING
-
     def __init__(self, coordinator, name: str, entry_id: str, device_type: str) -> None:
         super().__init__(coordinator, name, entry_id, device_type)
         self._attr_name = "Jobs"
         self._attr_unique_id = f"{entry_id}_jobs"
-
     @property
     def native_value(self) -> Any:
         d = self._data()
-        if self._unavailable():
-            return None
+        if self._unavailable(): return None
         wi = d.get("working_info")
         if isinstance(wi, dict) and isinstance(wi.get("data"), dict):
             return wi["data"].get("numOnlineWorking")
         return None
 
-    @property
-    def extra_state_attributes(self) -> dict[str, Any]:
-        d = self._data()
-        wi = d.get("working_info")
-        if not (isinstance(wi, dict) and isinstance(wi.get("data"), dict)):
-            return {}
-        return {
-            "online": wi["data"].get("numOnlineWorking"),
-            "offline": wi["data"].get("numOfflineWorking"),
-            "timeModeWorking": wi["data"].get("timeModeWorking"),
-            "timeSystemWork": wi["data"].get("timeSystemWork"),
-        }
-
-
 class XToolSystemRuntimeSensor(_BaseSensor):
     _attr_icon = "mdi:clock-outline"
     _attr_native_unit_of_measurement = UnitOfTime.HOURS
     _attr_state_class = SensorStateClass.TOTAL_INCREASING
-
     def __init__(self, coordinator, name: str, entry_id: str, device_type: str) -> None:
         super().__init__(coordinator, name, entry_id, device_type)
         self._attr_name = "System Runtime"
         self._attr_unique_id = f"{entry_id}_runtime_system"
-
     @property
     def native_value(self) -> Any:
         d = self._data()
-        if self._unavailable():
-            return None
+        if self._unavailable(): return None
         wi = d.get("working_info")
         if isinstance(wi, dict) and isinstance(wi.get("data"), dict):
             seconds = wi["data"].get("timeSystemWork")
-            if seconds is None:
-                return None
+            if seconds is None: return None
             return round(float(seconds) / 3600.0, 2)
         return None
 
-    @property
-    def extra_state_attributes(self) -> dict[str, Any]:
-        d = self._data()
-        wi = d.get("working_info")
-        if not (isinstance(wi, dict) and isinstance(wi.get("data"), dict)):
-            return {}
-        seconds = wi["data"].get("timeSystemWork")
-        if seconds is None:
-            return {}
-        hours = float(seconds) / 3600.0
-        return {"seconds": seconds, "days": round(hours / 24.0, 2)}
-
-
 class XToolFanStateSensor(_BaseSensor):
     _attr_icon = "mdi:fan"
-
     def __init__(self, coordinator, name: str, entry_id: str, device_type: str) -> None:
         super().__init__(coordinator, name, entry_id, device_type)
-        self._attr_name = "Exhaust Fan"
+        self._attr_name = "Exhaust Fan State"
         self._attr_unique_id = f"{entry_id}_fan_state"
-
     @property
     def native_value(self) -> Any:
-        if self._unavailable():
-            return None
-        return self._data().get("fan_state")
-
+        if self._unavailable(): return None
+        st = self._data().get("fan_state")
+        if st == "on": return "On"
+        if st == "off": return "Off"
+        return st
 
 class XToolExtPurifierStateSensor(_BaseSensor):
     _attr_icon = "mdi:air-filter"
-
     def __init__(self, coordinator, name: str, entry_id: str, device_type: str) -> None:
         super().__init__(coordinator, name, entry_id, device_type)
-        self._attr_name = "External Purifier"
+        self._attr_name = "External Purifier State"
         self._attr_unique_id = f"{entry_id}_ext_purifier"
-
     @property
     def native_value(self) -> Any:
-        if self._unavailable():
-            return None
-        return self._data().get("ext_purifier_state")
-
-    @property
-    def extra_state_attributes(self) -> dict[str, Any]:
-        d = self._data()
-        return {
-            "exist": d.get("ext_purifier_exist"),
-            "power": d.get("ext_purifier_power"),
-            "current": d.get("ext_purifier_current"),
-        }
-
+        if self._unavailable(): return None
+        st = self._data().get("ext_purifier_state")
+        if st == "on": return "On"
+        if st == "off": return "Off"
+        return st
 
 class XToolAirAssistSensor(_BaseSensor):
     _attr_icon = "mdi:weather-windy"
-
     def __init__(self, coordinator, name: str, entry_id: str, device_type: str) -> None:
         super().__init__(coordinator, name, entry_id, device_type)
-        self._attr_name = "AirAssist"
+        self._attr_name = "AirAssist State"
         self._attr_unique_id = f"{entry_id}_airassist"
-
     @property
     def native_value(self) -> Any:
-        if self._unavailable():
-            return None
-        return self._data().get("airassist_state")
-
-    @property
-    def extra_state_attributes(self) -> dict[str, Any]:
-        d = self._data()
-        return {
-            "power": d.get("airassist_power"),
-            "version": d.get("airassist_version"),
-            "fire_trigger_state": d.get("airassist_fire_trigger"),
-        }
-
+        if self._unavailable(): return None
+        st = self._data().get("airassist_state")
+        if st == "on": return "On"
+        if st == "off": return "Off"
+        return st
 
 class XToolLegacyWaterTempSensor(_BaseSensor):
     _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_icon = "mdi:thermometer-water"
-
     def __init__(self, coordinator, name: str, entry_id: str, device_type: str) -> None:
         super().__init__(coordinator, name, entry_id, device_type)
         self._attr_name = "Water Temp"
         self._attr_unique_id = f"{entry_id}_water_temp"
-
     @property
     def native_value(self) -> Any:
-        if self._unavailable():
-            return None
+        if self._unavailable(): return None
         legacy = self._data().get("legacy") if isinstance(self._data().get("legacy"), dict) else {}
         return legacy.get("WATER_TEMP")
 
-
 class XToolLegacyPurifierSensor(_BaseSensor):
     _attr_icon = "mdi:air-filter"
-
     def __init__(self, coordinator, name: str, entry_id: str, device_type: str) -> None:
         super().__init__(coordinator, name, entry_id, device_type)
         self._attr_name = "Purifier"
         self._attr_unique_id = f"{entry_id}_purifier"
-
     @property
     def native_value(self) -> Any:
-        if self._unavailable():
-            return None
+        if self._unavailable(): return None
         legacy = self._data().get("legacy") if isinstance(self._data().get("legacy"), dict) else {}
         return legacy.get("Purifier")
+
+# --- M1 Ultra Accessory Sensors ---
+class XToolBasicCarriageSensor(_BaseSensor):
+    _attr_icon = "mdi:tools"
+    def __init__(self, coordinator, name: str, entry_id: str, device_type: str) -> None:
+        super().__init__(coordinator, name, entry_id, device_type)
+        self._attr_name = "Basic Carriage"
+        self._attr_unique_id = f"{entry_id}_basic_carriage"
+    @property
+    def native_value(self) -> str | None:
+        if self._unavailable(): return None
+        val = self._data().get("workhead_driving")
+        if val is None: return "Waiting for data..."
+        try: 
+            val_int = int(val)
+        except (ValueError, TypeError): 
+            return f"Unknown ({val})"
+        
+        mapping = {
+            0: "Empty", 
+            15: "Laser 10W", 
+            16: "Laser 20W", 
+            29: "Knife holder", 
+            31: "Ink printer"
+        }
+        return mapping.get(val_int, f"Unknown ({val_int})")
+
+class XToolMultiFunctionCarriageSensor(_BaseSensor):
+    _attr_icon = "mdi:toolbox"
+    def __init__(self, coordinator, name: str, entry_id: str, device_type: str) -> None:
+        super().__init__(coordinator, name, entry_id, device_type)
+        self._attr_name = "Multi-function Carriage"
+        self._attr_unique_id = f"{entry_id}_multi_carriage"
+    @property
+    def native_value(self) -> str | None:
+        if self._unavailable(): return None
+        val = self._data().get("workhead_drived")
+        if val is None: return "Waiting for data..."
+        try: 
+            val_int = int(val)
+        except (ValueError, TypeError): 
+            return f"Unknown ({val})"
+            
+        mapping = {
+            41: "Empty", 
+            42: "Pen", 
+            43: "Fine Point Blade", 
+            44: "Hot Embossing"
+        }
+        return mapping.get(val_int, f"Unknown ({val_int})")
+
+class XToolMultiFunctionModuleSensor(_BaseSensor):
+    _attr_icon = "mdi:knife"
+    def __init__(self, coordinator, name: str, entry_id: str, device_type: str) -> None:
+        super().__init__(coordinator, name, entry_id, device_type)
+        self._attr_name = "Multi-function Module"
+        self._attr_unique_id = f"{entry_id}_multi_module"
+        
+    @property
+    def available(self) -> bool:
+        # Die Entität ist nur verfügbar, wenn der Messerhalter (ID 29) eingesetzt ist
+        if self._unavailable(): 
+            return False
+        carriage_id = self._data().get("workhead_driving")
+        if carriage_id is None:
+            return False
+        try:
+            return int(carriage_id) == 29
+        except (ValueError, TypeError):
+            return False
+
+    @property
+    def native_value(self) -> str | None:
+        if not self.available: 
+            return None
+        val = self._data().get("knife_driving")
+        if val is None: return "Waiting for data..."
+        try: 
+            val_int = int(val)
+        except (ValueError, TypeError): 
+            return f"Unknown ({val})"
+            
+        mapping = {
+            0: "Empty / Not synced", 
+            22: "Embossing", 
+            23: "Knife blade", 
+            24: "Rotary blade"
+        }
+        return mapping.get(val_int, f"Unknown ({val_int})")

--- a/custom_components/xtool/switch.py
+++ b/custom_components/xtool/switch.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN, MANUFACTURER
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    store = hass.data[DOMAIN][entry.entry_id]
+    coordinator = store["coordinator"]
+    name: str = store["name"]
+    entry_id: str = store["entry_id"]
+    device_type: str = store.get("device_type", "").lower()
+
+    if device_type != "d1":
+        async_add_entities([XToolExhaustFanSwitch(coordinator, name, entry_id, device_type)])
+
+
+class XToolExhaustFanSwitch(CoordinatorEntity, SwitchEntity):
+    _attr_has_entity_name = True
+    _attr_icon = "mdi:fan"
+
+    def __init__(self, coordinator, name: str, entry_id: str, device_type: str) -> None:
+        super().__init__(coordinator)
+        self._device_name = name
+        self._entry_id = entry_id
+        self._device_type = device_type
+        self._attr_name = "Exhaust Fan"
+        self._attr_unique_id = f"{entry_id}_exhaust_fan_switch"
+
+    @property
+    def device_info(self) -> dict[str, Any]:
+        return {
+            "identifiers": {(DOMAIN, self._entry_id)},
+            "name": self._device_name,
+            "manufacturer": MANUFACTURER,
+            "model": self._device_type.upper(),
+        }
+
+    @property
+    def available(self) -> bool:
+        data = self.coordinator.data or {}
+        return not bool(data.get("_unavailable"))
+
+    @property
+    def is_on(self) -> bool | None:
+        data = self.coordinator.data or {}
+        state = data.get("fan_state")
+        if state is None:
+            return None
+        return str(state).lower() == "on"
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        await self.coordinator.hass.async_add_executor_job(
+            self.coordinator._post, "/peripheral/smoking_fan", {"action": "on"}
+        )
+        await self.coordinator.async_request_refresh()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        await self.coordinator.hass.async_add_executor_job(
+            self.coordinator._post, "/peripheral/smoking_fan", {"action": "off"}
+        )
+        await self.coordinator.async_request_refresh()


### PR DESCRIPTION
Hi @BassXT,

Thank you so much for creating and maintaining this integration! 

I would like to give a massive thanks to **[@Flare0](https://github.com/Flare0)**. He did most of the pioneering work for the M1 Ultra support, providing the invaluable API endpoints and technical insights in the GitHub discussions. Without his groundwork, this update wouldn't have been possible.

Building upon that foundation, I have refined the implementation to make it work slightly better for Home Assistant. My focus was on improving the UI slightly (menus/sensors), enhancing tool detection, and solving the "wake-from-sleep" issue.

**⚠️ Important Note:** I have only tested these changes on my local **M1 Ultra** setup. I took great care to isolate the new logic (using `if device_type in ("m1u", "m1 ultra"):`) so the existing P2/F1/M1/D1 functions remain untouched, but it would be great if users with other machines could verify that their setups still work as expected.

### Key Changes & Features:

**1. Sleep Mode Optimization (No more accidental wake-ups)**
* Polling now prioritizes the `/device/runningStatus` endpoint, which is "silent" and doesn't wake the machine.
* Added an `is_sleeping` check: The integration now gracefully skips all active peripheral API calls (like checking gaps, locks, or fans) when the machine reports `SLEEP` or `STANDBY`.

**2. Refined Tool & Carriage Recognition**
* Integrated POST requests to `/peripheral/workhead_ID`, `/peripheral/knife_head`, and `/peripheral/inkjet_printer`.
* Added and cleaned up sensors for **Basic Carriage**, **Multi-function Carriage**, and **Multi-function Module**, mapping the IDs to human-readable states (e.g., Laser 10W, Pen, etc.).
* **Dynamic Availability:** The Multi-function Module sensor now automatically marks itself as "unavailable" if the Knife Holder is not inserted, keeping the UI clean.

**3. The "Knife Sync" Button Workaround**
* **The Problem:** The M1 Ultra API returns `0` (Unknown) for a newly inserted blade until a physical scan is performed.
* **The Solution:** Added a new `button.py` platform with a **Sync Knife Module** button. It is only visible/active when the Knife Holder (ID 29) is detected. It triggers the `get_sync` action so the machine identifies the blade.

**4. Exhaust Fan Switch & Accessory States**
* Added `switch.py` to toggle the Exhaust Fan.
* Split AirAssist, Fan, and Purifier into **Connectivity** (Binary Sensor) and **Active State** (Power Sensor) for better automation triggers.

**5. Logic Cleanup**
* Fixed inverted `lid` logic for M1 Ultra (API returns "off" for open).
* Renamed "Lid Open" to "Lid" and unified string outputs for better HA translation support.
* Removed the "Drawer Open" sensor for M1/M1 Ultra as it's not physically applicable.

I've been running this version for a while now and it works flawlessly on the M1 Ultra. Looking forward to your feedback!