### PR TITLE
Feature/s1 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,18 +59,49 @@ Entity IDs are automatically generated using the **Name** and **Device Type** yo
 | Name: `Laser1`, Type: `F1` | `binary_sensor.laser1_f1_power`<br>`sensor.laser1_f1_status` |
 | Name: `Laser2`, Type: `P2` | `binary_sensor.laser2_p2_power`<br>`sensor.laser2_p2_status` |
 | Name: `Studio`, Type: `M1` | `sensor.studio_m1_status`<br>`sensor.studio_m1_cpu_temp`<br>`sensor.studio_m1_water_temp`<br>`sensor.studio_m1_purifier` |
+| Name: `Laser3`, Type: `S1` | `binary_sensor.laser3_s1_power`<br>`binary_sensor.laser3_s1_running`<br>`binary_sensor.laser3_s1_alarm`<br>`sensor.laser3_s1_status`<br>`sensor.laser3_s1_firmware_version`<br>`sensor.laser3_s1_job_file`<br>`sensor.laser3_s1_position_x`<br>`sensor.laser3_s1_position_y`<br>`sensor.laser3_s1_fan_a`<br>`sensor.laser3_s1_fan_b` |
+
+**S1 with AP2 Air Cleaner** adds these additional entities (using the same name prefix):
+
+| Entity | Description |
+|--------|-------------|
+| `binary_sensor.laser3_s1_air_cleaner` | Air cleaner running state |
+| `sensor.laser3_s1_air_cleaner_model` | Air cleaner model |
+| `sensor.laser3_s1_air_cleaner_speed` | Fan speed |
+| `sensor.laser3_s1_air_cleaner_sensor_d` | Particle sensor D reading |
+| `sensor.laser3_s1_air_cleaner_sensor_s` | Particle sensor S reading |
+| `sensor.laser3_s1_pre_filter_remaining` | Pre-filter life remaining (%) |
+| `sensor.laser3_s1_medium_efficiency_filter_remaining` | Medium efficiency filter life remaining (%) |
+| `sensor.laser3_s1_activated_carbon_filter_remaining` | Activated carbon filter life remaining (%) |
+| `sensor.laser3_s1_ultra_dense_carbon_mesh_filter_remaining` | Ultra dense carbon mesh filter life remaining (%) |
+| `sensor.laser3_s1_high_efficiency_filter_remaining` | High efficiency filter life remaining (%) |
 
 ---
 
 ## 💬 Possible Status Values
 
+### P2, F1, M1, D1
+
 | Status | Meaning |
-|---------|----------|
+|--------|---------|
 | `Running` | The laser is currently engraving |
 | `Done` | The engraving job is finished |
 | `Idle` | The machine is idle |
 | `Sleep` | The device is in sleep mode |
 | `Ready` | (M1 only) machine ready for work |
+| `Unavailable` | Device offline or unreachable |
+| `Unknown` | Unknown or invalid response |
+
+### S1
+
+| Status | Meaning |
+|--------|---------|
+| `Ready` | Machine ready for work |
+| `Measuring` | Running auto-focus or measurement pass |
+| `Starting` | Job is initializing |
+| `Running` | The laser is currently engraving |
+| `Finishing` | Job is wrapping up |
+| `Idle` | The machine is idle |
 | `Unavailable` | Device offline or unreachable |
 | `Unknown` | Unknown or invalid response |
 

--- a/README.md
+++ b/README.md
@@ -171,7 +171,35 @@ action:
 mode: single
 ```
 
-### 🔹 4. Play an audio notification when Laser1 finishes
+### 🔹 4. Notify when Laser3 (S1) AP2 filter needs replacing
+```yaml
+alias: Laser3 – AP2 Filter Low
+description: Send a notification when any AP2 air cleaner filter drops below 10%
+triggers:
+  - trigger: numeric_state
+    entity_id: sensor.laser3_s1_pre_filter_remaining
+    below: 10
+  - trigger: numeric_state
+    entity_id: sensor.laser3_s1_medium_efficiency_filter_remaining
+    below: 10
+  - trigger: numeric_state
+    entity_id: sensor.laser3_s1_activated_carbon_filter_remaining
+    below: 10
+  - trigger: numeric_state
+    entity_id: sensor.laser3_s1_ultra_dense_carbon_mesh_filter_remaining
+    below: 10
+  - trigger: numeric_state
+    entity_id: sensor.laser3_s1_high_efficiency_filter_remaining
+    below: 10
+actions:
+  - service: notify.mobile_app_my_phone
+    data:
+      title: "xTool Laser3 – AP2 Filter Low"
+      message: "An AP2 air cleaner filter is below 10%. Check the filter status and replace if needed."
+mode: single
+```
+
+### 🔹 5. Play an audio notification when Laser1 finishes
 ```yaml
 alias: Laser1 – Audio Notification
 description: Play a short audio clip when Laser1 (F1) completes a job

--- a/README.md
+++ b/README.md
@@ -173,30 +173,67 @@ mode: single
 
 ### 🔹 4. Notify when Laser3 (S1) AP2 filter needs replacing
 ```yaml
-alias: Laser3 – AP2 Filter Low
-description: Send a notification when any AP2 air cleaner filter drops below 10%
-triggers:
-  - trigger: numeric_state
+# NOTE: Adjust entity ID prefixes to match your device name from integration setup.
+# Check Settings -> Devices -> your S1 device to confirm exact entity IDs.
+alias: xTool AP2 - Filter Replacement Warning
+description: >
+  Persistent notification when any AP2 filter drops below 25% remaining.
+  Critical alert when below 15%.
+
+trigger:
+  - platform: numeric_state
     entity_id: sensor.laser3_s1_pre_filter_remaining
-    below: 10
-  - trigger: numeric_state
+    below: 25
+    id: pre_filter
+    variables:
+      filter_name: "Pre-filter"
+
+  - platform: numeric_state
     entity_id: sensor.laser3_s1_medium_efficiency_filter_remaining
-    below: 10
-  - trigger: numeric_state
+    below: 25
+    id: medium_filter
+    variables:
+      filter_name: "Medium Efficiency Filter"
+
+  - platform: numeric_state
     entity_id: sensor.laser3_s1_activated_carbon_filter_remaining
-    below: 10
-  - trigger: numeric_state
+    below: 25
+    id: carbon_filter
+    variables:
+      filter_name: "Activated Carbon Filter"
+
+  - platform: numeric_state
     entity_id: sensor.laser3_s1_ultra_dense_carbon_mesh_filter_remaining
-    below: 10
-  - trigger: numeric_state
+    below: 25
+    id: dense_carbon_filter
+    variables:
+      filter_name: "Ultra Dense Carbon Mesh Filter"
+
+  - platform: numeric_state
     entity_id: sensor.laser3_s1_high_efficiency_filter_remaining
-    below: 10
-actions:
-  - service: notify.mobile_app_my_phone
+    below: 25
+    id: hepa_filter
+    variables:
+      filter_name: "High Efficiency Filter"
+
+action:
+  - service: persistent_notification.create
     data:
-      title: "xTool Laser3 – AP2 Filter Low"
-      message: "An AP2 air cleaner filter is below 10%. Check the filter status and replace if needed."
-mode: single
+      notification_id: "ap2_filter_{{ trigger.id }}"
+      title: >
+        {% if trigger.to_state.state | float < 15 %}
+          Critical: AP2 Filter Replacement Required
+        {% else %}
+          AP2 Filter Replacement Warning
+        {% endif %}
+      message: >
+        {% if trigger.to_state.state | float < 15 %}
+          Critical:
+        {% endif %}
+        {{ filter_name }} is at {{ trigger.to_state.state }}% remaining.
+
+mode: parallel
+max: 5
 ```
 
 ### 🔹 5. Play an audio notification when Laser1 finishes

--- a/ap2_filter_warning.yaml
+++ b/ap2_filter_warning.yaml
@@ -1,0 +1,76 @@
+# AP2 Air Cleaner Filter Replacement Warning
+#
+# Sends a persistent notification when any filter drops below 25% remaining.
+# Notification is prefixed with "Critical:" if below 15%.
+#
+# NOTE: VERIFY ENTITY IDS BEFORE IMPLEMENTING. They depend on the device name
+# assigned during integration setup. Check Settings -> Devices -> your S1 device
+# to confirm the exact entity IDs.
+#
+# Expected entity IDs (adjust prefix if your device is named differently):
+#   sensor.s1_pre_filter_remaining
+#   sensor.s1_medium_efficiency_filter_remaining
+#   sensor.s1_activated_carbon_filter_remaining
+#   sensor.s1_ultra_dense_carbon_mesh_filter_remaining
+#   sensor.s1_high_efficiency_filter_remaining
+
+alias: xTool AP2 - Filter Replacement Warning
+description: >
+  Persistent notification when any AP2 filter drops below 25% remaining.
+  Critical alert when below 15%.
+
+trigger:
+  - platform: numeric_state
+    entity_id: sensor.s1_pre_filter_remaining
+    below: 25
+    id: pre_filter
+    variables:
+      filter_name: "Pre-filter"
+
+  - platform: numeric_state
+    entity_id: sensor.s1_medium_efficiency_filter_remaining
+    below: 25
+    id: medium_filter
+    variables:
+      filter_name: "Medium Efficiency Filter"
+
+  - platform: numeric_state
+    entity_id: sensor.s1_activated_carbon_filter_remaining
+    below: 25
+    id: carbon_filter
+    variables:
+      filter_name: "Activated Carbon Filter"
+
+  - platform: numeric_state
+    entity_id: sensor.s1_ultra_dense_carbon_mesh_filter_remaining
+    below: 25
+    id: dense_carbon_filter
+    variables:
+      filter_name: "Ultra Dense Carbon Mesh Filter"
+
+  - platform: numeric_state
+    entity_id: sensor.s1_high_efficiency_filter_remaining
+    below: 25
+    id: hepa_filter
+    variables:
+      filter_name: "High Efficiency Filter"
+
+action:
+  - service: persistent_notification.create
+    data:
+      # Unique ID per filter so each gets its own notification
+      notification_id: "ap2_filter_{{ trigger.id }}"
+      title: >
+        {% if trigger.to_state.state | float < 15 %}
+          Critical: AP2 Filter Replacement Required
+        {% else %}
+          AP2 Filter Replacement Warning
+        {% endif %}
+      message: >
+        {% if trigger.to_state.state | float < 15 %}
+          Critical:
+        {% endif %}
+        {{ filter_name }} is at {{ trigger.to_state.state }}% remaining.
+
+mode: parallel
+max: 5

--- a/custom_components/xtool/__init__.py
+++ b/custom_components/xtool/__init__.py
@@ -12,6 +12,7 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .coordinator_d1 import XToolD1Coordinator
+from .coordinator_s1 import XToolS1Coordinator
 from .const import (
     DOMAIN,
     PLATFORMS,
@@ -483,6 +484,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     if dev_type == "d1":
         coordinator: DataUpdateCoordinator = XToolD1Coordinator(hass, ip)
+        await coordinator.async_config_entry_first_refresh()
+    elif dev_type == "s1":
+        coordinator = XToolS1Coordinator(hass, ip)
         await coordinator.async_config_entry_first_refresh()
     else:
         coordinator = XToolCoordinator(hass, ip, dev_type)

--- a/custom_components/xtool/__init__.py
+++ b/custom_components/xtool/__init__.py
@@ -18,6 +18,7 @@ from .const import (
     PLATFORMS,
     CONF_IP_ADDRESS,
     CONF_DEVICE_TYPE,
+    CONF_HAS_AP2,
     DEFAULT_UPDATE_INTERVAL,
     DEFAULT_SLOW_UPDATE_INTERVAL,
     HTTP_TIMEOUT,
@@ -486,7 +487,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         coordinator: DataUpdateCoordinator = XToolD1Coordinator(hass, ip)
         await coordinator.async_config_entry_first_refresh()
     elif dev_type == "s1":
-        coordinator = XToolS1Coordinator(hass, ip)
+        has_ap2 = entry.data.get(CONF_HAS_AP2, False)
+        coordinator = XToolS1Coordinator(hass, ip, has_ap2=has_ap2)
         await coordinator.async_config_entry_first_refresh()
     else:
         coordinator = XToolCoordinator(hass, ip, dev_type)

--- a/custom_components/xtool/api_s1.py
+++ b/custom_components/xtool/api_s1.py
@@ -26,9 +26,14 @@ _M222_RE = re.compile(r'S(\S+)')
 _M810_RE = re.compile(r'"([^"]*)"')
 # Regex for M303 "X... Y..."
 _M303_RE = re.compile(r'X([+-]?\d+\.\d+)\s+Y([+-]?\d+\.\d+)')
-# Regex for M9039 purifier: speed field "A{n}" (on) or "C{n}" (off), humidity "H{n}"
+# Regex for M9039 purifier: speed field "A{n}" (on) or "C{n}" (off), filter remaining H-L
 _M9039_SPEED_RE = re.compile(r'([AC])(\d+)')
-_M9039_H_RE = re.compile(r'H(\d+)')
+# Filter remaining fields: H=pre-filter, I=medium efficiency, J=activated carbon,
+# K=ultra dense carbon mesh, L=high efficiency
+_M9039_FILTERS_RE = re.compile(r'H(\d+).*I(\d+).*J(\d+).*K(\d+).*L(\d+)')
+# Unknown fields D and S
+_M9039_D_RE = re.compile(r'D(\d+)')
+_M9039_S_RE = re.compile(r'S(\d+)')
 
 
 def _parse_m27(val: str) -> dict[str, Any]:
@@ -130,6 +135,10 @@ class XToolS1Api:
         """Send M303 as keepalive/position refresh."""
         await self._send("M303\n")
 
+    async def request_purifier_status(self) -> None:
+        """Send M9039 to request current air cleaner state."""
+        await self._send("M9039\n")
+
     async def _send(self, text: str) -> None:
         if not self.connected:
             return
@@ -144,6 +153,16 @@ class XToolS1Api:
             async for msg in self._ws:
                 if msg.type == WSMsgType.TEXT:
                     self._handle_message(msg.data)
+                elif msg.type == WSMsgType.BINARY:
+                    # Some messages (e.g. M9039) arrive as binary frames with a
+                    # binary header/footer. Extract the M-code text payload.
+                    try:
+                        decoded = msg.data.decode("latin-1")
+                        m = re.search(r'(M\d+ \S.*)', decoded)
+                        if m:
+                            self._handle_message(m.group(1))
+                    except Exception as err:
+                        _LOGGER.debug("S1 %s binary frame parse error: %s", self._ip, err)
                 elif msg.type in (WSMsgType.CLOSE, WSMsgType.ERROR, WSMsgType.CLOSED):
                     break
         except asyncio.CancelledError:
@@ -213,10 +232,21 @@ class XToolS1Api:
                     speed = 0 if prefix == "C" else num
                     self._state["purifier_speed"] = speed
                     self._state["purifier_on"] = speed > 0
-                # H{n} = humidity percent
-                h = _M9039_H_RE.search(body)
-                if h:
-                    self._state["purifier_humidity"] = int(h.group(1))
+                # H-L = filter remaining percentages
+                f = _M9039_FILTERS_RE.search(body)
+                if f:
+                    self._state["filter_pre"] = int(f.group(1))
+                    self._state["filter_medium"] = int(f.group(2))
+                    self._state["filter_carbon"] = int(f.group(3))
+                    self._state["filter_dense_carbon"] = int(f.group(4))
+                    self._state["filter_hepa"] = int(f.group(5))
+                # D and S = unknown fields
+                d = _M9039_D_RE.search(body)
+                if d:
+                    self._state["purifier_sensor_d"] = int(d.group(1))
+                s = _M9039_S_RE.search(body)
+                if s:
+                    self._state["purifier_sensor_s"] = int(s.group(1))
 
         except Exception as err:
             _LOGGER.debug("S1 %s message parse error: %s | text=%r", self._ip, err, text)

--- a/custom_components/xtool/api_s1.py
+++ b/custom_components/xtool/api_s1.py
@@ -1,0 +1,280 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+from typing import Any
+
+from aiohttp import ClientSession, ClientWebSocketResponse, WSMsgType
+
+_LOGGER = logging.getLogger(__name__)
+
+_WS_PORT = 8081
+_CONNECT_TIMEOUT = 8.0
+_SEND_TIMEOUT = 5.0
+
+# Regex for M105 format "X0.00Y0.00Z0.00" (no spaces between axes)
+_M105_RE = re.compile(r'([XYZ])([+-]?\d+\.\d+)')
+# Regex for M313 "Zxx.xxx"
+_M313_RE = re.compile(r'Z([+-]?\d+\.\d+)')
+# Regex for M340 "Axx"
+_M340_RE = re.compile(r'A(\S+)')
+# Regex for M222 "Sxx"
+_M222_RE = re.compile(r'S(\S+)')
+# Regex for M810 filename (quoted)
+_M810_RE = re.compile(r'"([^"]*)"')
+# Regex for M303 "X... Y..."
+_M303_RE = re.compile(r'X([+-]?\d+\.\d+)\s+Y([+-]?\d+\.\d+)')
+# Regex for M9039 purifier: speed field "A{n}" (on) or "C{n}" (off), humidity "H{n}"
+_M9039_SPEED_RE = re.compile(r'([AC])(\d+)')
+_M9039_H_RE = re.compile(r'H(\d+)')
+
+
+def _parse_m27(val: str) -> dict[str, Any]:
+    """Parse 'X-0.010 Y99.200 Z0.000 U0.000' into pos_x/y/z/u floats."""
+    out: dict[str, Any] = {}
+    key_map = {"X": "pos_x", "Y": "pos_y", "Z": "pos_z", "U": "pos_u"}
+    for part in val.split():
+        if part and part[0] in key_map:
+            try:
+                out[key_map[part[0]]] = float(part[1:])
+            except ValueError:
+                pass
+    return out
+
+
+def _parse_m105(val: str) -> dict[str, Any]:
+    """Parse 'X0.00Y0.00Z0.00' (no spaces) into temp_x/y/z floats."""
+    out: dict[str, Any] = {}
+    key_map = {"X": "temp_x", "Y": "temp_y", "Z": "temp_z"}
+    for match in _M105_RE.finditer(val):
+        axis, num = match.group(1), match.group(2)
+        if axis in key_map:
+            try:
+                out[key_map[axis]] = float(num)
+            except ValueError:
+                pass
+    return out
+
+
+def _parse_m13(val: str) -> dict[str, Any]:
+    """Parse 'A70 B70' into fan_a/fan_b ints."""
+    out: dict[str, Any] = {}
+    for part in val.split():
+        if part.startswith("A"):
+            try:
+                out["fan_a"] = int(part[1:])
+            except ValueError:
+                pass
+        elif part.startswith("B"):
+            try:
+                out["fan_b"] = int(part[1:])
+            except ValueError:
+                pass
+    return out
+
+
+class XToolS1Api:
+    """WebSocket API client for the xTool S1."""
+
+    def __init__(self, ip_address: str, session: ClientSession) -> None:
+        self._ip = ip_address
+        self._session = session
+        self._ws: ClientWebSocketResponse | None = None
+        self._listen_task: asyncio.Task | None = None
+        self._state: dict[str, Any] = {"_unavailable": True}
+
+    @property
+    def connected(self) -> bool:
+        return self._ws is not None and not self._ws.closed
+
+    @property
+    def state(self) -> dict[str, Any]:
+        return self._state
+
+    async def connect(self) -> bool:
+        """Open WebSocket connection and start background listener."""
+        url = f"ws://{self._ip}:{_WS_PORT}/"
+        try:
+            self._ws = await self._session.ws_connect(
+                url, timeout=_CONNECT_TIMEOUT, heartbeat=30
+            )
+            self._state = {"_unavailable": False}
+            self._listen_task = asyncio.ensure_future(self._listen_loop())
+            _LOGGER.debug("S1 %s WebSocket connected", self._ip)
+            return True
+        except Exception as err:
+            _LOGGER.debug("S1 %s WebSocket connect failed: %s", self._ip, err)
+            self._ws = None
+            return False
+
+    async def disconnect(self) -> None:
+        """Cancel listener and close WebSocket."""
+        if self._listen_task and not self._listen_task.done():
+            self._listen_task.cancel()
+            try:
+                await self._listen_task
+            except asyncio.CancelledError:
+                pass
+        self._listen_task = None
+        if self._ws and not self._ws.closed:
+            await self._ws.close()
+        self._ws = None
+
+    async def request_status(self) -> None:
+        """Send M2003 to trigger a full status push from the device."""
+        await self._send("M2003\n")
+
+    async def ping(self) -> None:
+        """Send M303 as keepalive/position refresh."""
+        await self._send("M303\n")
+
+    async def _send(self, text: str) -> None:
+        if not self.connected:
+            return
+        try:
+            await asyncio.wait_for(self._ws.send_str(text), timeout=_SEND_TIMEOUT)
+        except Exception as err:
+            _LOGGER.debug("S1 %s send error: %s", self._ip, err)
+
+    async def _listen_loop(self) -> None:
+        """Background task: read frames and update _state."""
+        try:
+            async for msg in self._ws:
+                if msg.type == WSMsgType.TEXT:
+                    self._handle_message(msg.data)
+                elif msg.type in (WSMsgType.CLOSE, WSMsgType.ERROR, WSMsgType.CLOSED):
+                    break
+        except asyncio.CancelledError:
+            raise
+        except Exception as err:
+            _LOGGER.debug("S1 %s listen error: %s", self._ip, err)
+        finally:
+            _LOGGER.debug("S1 %s WebSocket listener stopped", self._ip)
+            self._state["_unavailable"] = True
+            self._ws = None
+
+    def _handle_message(self, text: str) -> None:
+        """Parse an incoming WebSocket frame and merge into _state."""
+        text = text.strip()
+        if not text:
+            return
+
+        try:
+            if text.startswith("M2003{"):
+                # Full status JSON: strip prefix, parse JSON
+                json_str = text[len("M2003"):]
+                data = json.loads(json_str)
+                self._state.update(self._parse_m2003(data))
+                self._state["_unavailable"] = False
+
+            elif text.startswith("M222 "):
+                m = _M222_RE.search(text[5:])
+                if m:
+                    self._state["work_state_raw"] = m.group(1)
+
+            elif text.startswith("M810 "):
+                m = _M810_RE.search(text[5:])
+                if m:
+                    val = m.group(1)
+                    self._state["job_file"] = None if val.upper() == "NULL" else val
+
+            elif text.startswith("M340 "):
+                m = _M340_RE.search(text[5:])
+                if m:
+                    alarm_raw = m.group(1)
+                    self._state["alarm_raw"] = alarm_raw
+                    self._state["alarm_present"] = (alarm_raw != "A0" and alarm_raw != "0")
+
+            elif text.startswith("M303 "):
+                m = _M303_RE.search(text[5:])
+                if m:
+                    try:
+                        self._state["pos_x"] = float(m.group(1))
+                        self._state["pos_y"] = float(m.group(2))
+                    except ValueError:
+                        pass
+
+            elif text.startswith("M313 "):
+                m = _M313_RE.search(text[5:])
+                if m:
+                    try:
+                        self._state["probe_z"] = float(m.group(1))
+                    except ValueError:
+                        pass
+
+            elif text.startswith("M9039 "):
+                body = text[6:]
+                # A{n} = running at speed n (1-4), C{n} = off
+                m = _M9039_SPEED_RE.search(body)
+                if m:
+                    prefix, num = m.group(1), int(m.group(2))
+                    speed = 0 if prefix == "C" else num
+                    self._state["purifier_speed"] = speed
+                    self._state["purifier_on"] = speed > 0
+                # H{n} = humidity percent
+                h = _M9039_H_RE.search(body)
+                if h:
+                    self._state["purifier_humidity"] = int(h.group(1))
+
+        except Exception as err:
+            _LOGGER.debug("S1 %s message parse error: %s | text=%r", self._ip, err, text)
+
+    def _parse_m2003(self, data: dict[str, Any]) -> dict[str, Any]:
+        """Map M2003 JSON fields to normalized _state keys."""
+        out: dict[str, Any] = {}
+
+        # Work state from M222 field (primary state indicator, M97 is ignored)
+        m222 = data.get("M222")
+        if m222 is not None:
+            # M222 value in JSON may be "S3" or just "3" depending on firmware
+            raw = str(m222).strip()
+            if not raw.startswith("S"):
+                raw = "S" + raw
+            out["work_state_raw"] = raw
+
+        # Position
+        m27 = data.get("M27")
+        if m27:
+            out.update(_parse_m27(str(m27)))
+
+        # Serial number
+        m310 = data.get("M310")
+        if m310:
+            out["serial_number"] = str(m310).strip()
+
+        # Firmware version
+        m99 = data.get("M99")
+        if m99:
+            out["firmware_version"] = str(m99).strip()
+
+        # Tool type
+        m54 = data.get("M54")
+        if m54:
+            out["tool_type"] = str(m54).strip()
+
+        # Temperatures
+        m105 = data.get("M105")
+        if m105:
+            out.update(_parse_m105(str(m105)))
+
+        # Fan speeds
+        m13 = data.get("M13")
+        if m13:
+            out.update(_parse_m13(str(m13)))
+
+        # Alarm state from M340 key
+        m340 = data.get("M340")
+        if m340 is not None:
+            alarm_raw = str(m340).strip()
+            out["alarm_raw"] = alarm_raw
+            out["alarm_present"] = (alarm_raw != "A0" and alarm_raw != "0")
+
+        # Job file from M810 key
+        m810 = data.get("M810")
+        if m810 is not None:
+            val = str(m810).strip().strip('"')
+            out["job_file"] = None if val.upper() == "NULL" else val
+
+        return out

--- a/custom_components/xtool/binary_sensor.py
+++ b/custom_components/xtool/binary_sensor.py
@@ -199,7 +199,7 @@ class S1AlarmBinarySensor(_BaseBinary):
 
     @property
     def available(self) -> bool:
-        return not self._unavailable()
+        return self.coordinator.last_update_success and not self._unavailable()
 
     @property
     def is_on(self) -> bool:
@@ -217,9 +217,11 @@ class S1PurifierRunningBinarySensor(_BaseBinary):
 
     @property
     def available(self) -> bool:
-        if self._unavailable():
-            return False
-        return self._data().get("purifier_on") is not None
+        return (
+            self.coordinator.last_update_success
+            and not self._unavailable()
+            and self._data().get("purifier_on") is not None
+        )
 
     @property
     def is_on(self) -> bool:

--- a/custom_components/xtool/binary_sensor.py
+++ b/custom_components/xtool/binary_sensor.py
@@ -29,6 +29,18 @@ async def async_setup_entry(
     d = coordinator.data or {}
     entities: list[BinarySensorEntity] = []
 
+    if device_type == "s1":
+        entities.extend(
+            [
+                S1PowerBinarySensor(coordinator, name, entry_id, device_type),
+                S1RunningBinarySensor(coordinator, name, entry_id, device_type),
+                S1AlarmBinarySensor(coordinator, name, entry_id, device_type),
+                S1PurifierRunningBinarySensor(coordinator, name, entry_id, device_type),
+            ]
+        )
+        async_add_entities(entities, True)
+        return
+
     if device_type == "d1":
         entities.extend(
             [
@@ -147,6 +159,71 @@ class _BaseBinary(CoordinatorEntity, BinarySensorEntity):
 
     def _unavailable(self) -> bool:
         return bool(self._data().get("_unavailable"))
+
+
+# --- S1 ---
+class S1PowerBinarySensor(_BaseBinary):
+    _attr_device_class = BinarySensorDeviceClass.POWER
+
+    def __init__(self, coordinator, name: str, entry_id: str, device_type: str) -> None:
+        super().__init__(coordinator, name, entry_id, device_type)
+        self._attr_name = "Power"
+        self._attr_unique_id = f"{entry_id}_s1_power"
+
+    @property
+    def is_on(self) -> bool:
+        return (not self._unavailable()) and bool(self.coordinator.last_update_success)
+
+
+class S1RunningBinarySensor(_BaseBinary):
+    _attr_device_class = BinarySensorDeviceClass.RUNNING
+
+    def __init__(self, coordinator, name: str, entry_id: str, device_type: str) -> None:
+        super().__init__(coordinator, name, entry_id, device_type)
+        self._attr_name = "Running"
+        self._attr_unique_id = f"{entry_id}_s1_running"
+
+    @property
+    def is_on(self) -> bool:
+        # S13=Starting, S14=Running, S19=Finishing are all "active" states
+        return self._data().get("work_state_raw") in ("S13", "S14", "S19")
+
+
+class S1AlarmBinarySensor(_BaseBinary):
+    _attr_device_class = BinarySensorDeviceClass.PROBLEM
+
+    def __init__(self, coordinator, name: str, entry_id: str, device_type: str) -> None:
+        super().__init__(coordinator, name, entry_id, device_type)
+        self._attr_name = "Alarm"
+        self._attr_unique_id = f"{entry_id}_s1_alarm"
+
+    @property
+    def available(self) -> bool:
+        return not self._unavailable()
+
+    @property
+    def is_on(self) -> bool:
+        return self._data().get("alarm_present") is True
+
+
+class S1PurifierRunningBinarySensor(_BaseBinary):
+    _attr_device_class = BinarySensorDeviceClass.RUNNING
+    _attr_icon = "mdi:air-purifier"
+
+    def __init__(self, coordinator, name: str, entry_id: str, device_type: str) -> None:
+        super().__init__(coordinator, name, entry_id, device_type)
+        self._attr_name = "Air Cleaner"
+        self._attr_unique_id = f"{entry_id}_s1_purifier_running"
+
+    @property
+    def available(self) -> bool:
+        if self._unavailable():
+            return False
+        return self._data().get("purifier_on") is not None
+
+    @property
+    def is_on(self) -> bool:
+        return bool(self._data().get("purifier_on"))
 
 
 # --- D1 ---

--- a/custom_components/xtool/config_flow.py
+++ b/custom_components/xtool/config_flow.py
@@ -11,6 +11,7 @@ from .const import (
     DOMAIN,
     CONF_IP_ADDRESS,
     CONF_DEVICE_TYPE,
+    CONF_HAS_AP2,
     SUPPORTED_DEVICE_TYPES,
 )
 
@@ -28,8 +29,15 @@ class XToolConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    def __init__(self) -> None:
+        self._data: dict = {}
+
     async def async_step_user(self, user_input: dict | None = None) -> FlowResult:
         if user_input is not None:
+            self._data.update(user_input)
+            # S1 users may optionally have an AP2 air cleaner — ask on next step
+            if user_input[CONF_DEVICE_TYPE] == "S1":
+                return await self.async_step_s1_accessories()
             return self.async_create_entry(
                 title=user_input[CONF_NAME],
                 data={
@@ -43,9 +51,29 @@ class XToolConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         schema = vol.Schema(
             {
-                vol.Required(CONF_NAME): cv.string,       # z. B. "Laser Werkstatt"
+                vol.Required(CONF_NAME): cv.string,       # e.g. "Laser Workshop"
                 vol.Required(CONF_IP_ADDRESS): cv.string, # 192.168.x.x
-                vol.Required(CONF_DEVICE_TYPE): vol.In(options),  # kein Default
+                vol.Required(CONF_DEVICE_TYPE): vol.In(options),
             }
         )
         return self.async_show_form(step_id="user", data_schema=schema)
+
+    async def async_step_s1_accessories(self, user_input: dict | None = None) -> FlowResult:
+        """Second step for S1: ask whether an AP2 air cleaner is attached."""
+        if user_input is not None:
+            return self.async_create_entry(
+                title=self._data[CONF_NAME],
+                data={
+                    CONF_NAME: self._data[CONF_NAME],
+                    CONF_IP_ADDRESS: self._data[CONF_IP_ADDRESS],
+                    CONF_DEVICE_TYPE: self._data[CONF_DEVICE_TYPE],
+                    CONF_HAS_AP2: user_input.get(CONF_HAS_AP2, False),
+                },
+            )
+
+        schema = vol.Schema(
+            {
+                vol.Required(CONF_HAS_AP2, default=False): cv.boolean,
+            }
+        )
+        return self.async_show_form(step_id="s1_accessories", data_schema=schema)

--- a/custom_components/xtool/const.py
+++ b/custom_components/xtool/const.py
@@ -17,6 +17,7 @@ SUPPORTED_DEVICE_TYPES: dict[str, str] = {
     "F2 Ultra UV": "f2uuv",
     "M1": "m1",
     "M1 Ultra": "m1u",
+    "S1": "s1",
     "D1": "d1",
     "Apparel Printer": "apparel"
 }

--- a/custom_components/xtool/const.py
+++ b/custom_components/xtool/const.py
@@ -6,6 +6,7 @@ PLATFORMS: list[str] = ["sensor", "binary_sensor", "camera", "switch", "button"]
 
 CONF_IP_ADDRESS = "ip_address"
 CONF_DEVICE_TYPE = "device_type"
+CONF_HAS_AP2 = "has_ap2"  # Whether the S1 has an AP2 air cleaner attached
 
 # Mapping of display names to internal device type codes
 SUPPORTED_DEVICE_TYPES: dict[str, str] = {

--- a/custom_components/xtool/coordinator_d1.py
+++ b/custom_components/xtool/coordinator_d1.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import timedelta
+import logging
 from typing import Any
 
 from homeassistant.core import HomeAssistant
@@ -10,11 +11,14 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from .api_d1 import XToolD1Api
 from .const import DEFAULT_UPDATE_INTERVAL
 
+_LOGGER = logging.getLogger(__name__)
+
 
 class XToolD1Coordinator(DataUpdateCoordinator[dict[str, Any]]):
     def __init__(self, hass: HomeAssistant, ip_address: str) -> None:
         super().__init__(
             hass,
+            _LOGGER,
             name=f"xtool_d1_{ip_address}",
             update_interval=timedelta(seconds=DEFAULT_UPDATE_INTERVAL),
         )

--- a/custom_components/xtool/coordinator_s1.py
+++ b/custom_components/xtool/coordinator_s1.py
@@ -31,7 +31,7 @@ _WORK_STATE_MAP = {
 class XToolS1Coordinator(DataUpdateCoordinator[dict[str, Any]]):
     """Coordinator for the xTool S1 (WebSocket protocol on port 8081)."""
 
-    def __init__(self, hass: HomeAssistant, ip_address: str) -> None:
+    def __init__(self, hass: HomeAssistant, ip_address: str, has_ap2: bool = False) -> None:
         super().__init__(
             hass,
             _LOGGER,
@@ -39,6 +39,7 @@ class XToolS1Coordinator(DataUpdateCoordinator[dict[str, Any]]):
             update_interval=timedelta(seconds=DEFAULT_UPDATE_INTERVAL),
         )
         self.ip_address = ip_address
+        self.has_ap2 = has_ap2
         self.api = XToolS1Api(ip_address, async_get_clientsession(hass))
 
         # Cache static fields so they survive a bad poll tick
@@ -57,9 +58,10 @@ class XToolS1Coordinator(DataUpdateCoordinator[dict[str, Any]]):
             ok = await self.api.connect()
             if not ok:
                 raise UpdateFailed(f"Cannot connect to S1 at {self.ip_address}:8081")
-            # Request full status dump and air cleaner state, wait briefly for pushes
+            # Request full status dump, then air cleaner state if AP2 is present
             await self.api.request_status()
-            await self.api.request_purifier_status()
+            if self.has_ap2:
+                await self.api.request_purifier_status()
             await asyncio.sleep(_INITIAL_WAIT)
 
         # Send keepalive / position refresh

--- a/custom_components/xtool/coordinator_s1.py
+++ b/custom_components/xtool/coordinator_s1.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import timedelta
+import logging
+from typing import Any
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .api_s1 import XToolS1Api
+from .const import DEFAULT_UPDATE_INTERVAL
+
+_LOGGER = logging.getLogger(__name__)
+
+# Seconds to wait after requesting status before reading _state on first connect.
+# Gives the device time to push back the M2003 response.
+_INITIAL_WAIT = 1.5
+
+_WORK_STATE_MAP = {
+    "S3":  "Idle",
+    "S10": "Measuring",
+    "S1":  "Ready",
+    "S13": "Starting",
+    "S14": "Running",
+    "S19": "Finishing",
+}
+
+
+class XToolS1Coordinator(DataUpdateCoordinator[dict[str, Any]]):
+    """Coordinator for the xTool S1 (WebSocket protocol on port 8081)."""
+
+    def __init__(self, hass: HomeAssistant, ip_address: str) -> None:
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=f"xtool_s1_{ip_address}",
+            update_interval=timedelta(seconds=DEFAULT_UPDATE_INTERVAL),
+        )
+        self.ip_address = ip_address
+        self.api = XToolS1Api(ip_address, async_get_clientsession(hass))
+
+        # Cache static fields so they survive a bad poll tick
+        self._cached_serial: str | None = None
+        self._cached_firmware: str | None = None
+
+    @staticmethod
+    def map_work_state(raw: str | None) -> str:
+        """Map M222 state code to a human-readable string."""
+        if raw is None:
+            return "Unknown"
+        return _WORK_STATE_MAP.get(str(raw).strip(), f"Unknown ({raw})")
+
+    async def _async_update_data(self) -> dict[str, Any]:
+        if not self.api.connected:
+            ok = await self.api.connect()
+            if not ok:
+                raise UpdateFailed(f"Cannot connect to S1 at {self.ip_address}:8081")
+            # Request a full status dump and wait briefly for the device to push it back
+            await self.api.request_status()
+            await asyncio.sleep(_INITIAL_WAIT)
+
+        # Send keepalive / position refresh
+        await self.api.ping()
+
+        # Snapshot the state that the background listener has been updating
+        data = dict(self.api.state)
+
+        # Cache static fields
+        if data.get("serial_number"):
+            self._cached_serial = data["serial_number"]
+        if data.get("firmware_version"):
+            self._cached_firmware = data["firmware_version"]
+
+        data.setdefault("serial_number", self._cached_serial)
+        data.setdefault("firmware_version", self._cached_firmware)
+
+        return data

--- a/custom_components/xtool/coordinator_s1.py
+++ b/custom_components/xtool/coordinator_s1.py
@@ -57,8 +57,9 @@ class XToolS1Coordinator(DataUpdateCoordinator[dict[str, Any]]):
             ok = await self.api.connect()
             if not ok:
                 raise UpdateFailed(f"Cannot connect to S1 at {self.ip_address}:8081")
-            # Request a full status dump and wait briefly for the device to push it back
+            # Request full status dump and air cleaner state, wait briefly for pushes
             await self.api.request_status()
+            await self.api.request_purifier_status()
             await asyncio.sleep(_INITIAL_WAIT)
 
         # Send keepalive / position refresh

--- a/custom_components/xtool/manifest.json
+++ b/custom_components/xtool/manifest.json
@@ -9,5 +9,5 @@
   "issue_tracker": "https://github.com/BassXT/xtool/issues",
   "loggers": ["custom_components.xtool"],
   "requirements": ["requests"],
-  "version": "2.3.1"
+  "version": "2.4.0"
 }

--- a/custom_components/xtool/sensor.py
+++ b/custom_components/xtool/sensor.py
@@ -52,7 +52,13 @@ async def async_setup_entry(
                 S1FanBSensor(coordinator, name, entry_id, device_type),
                 S1PurifierModelSensor(coordinator, name, entry_id, device_type),
                 S1PurifierSpeedSensor(coordinator, name, entry_id, device_type),
-                S1PurifierHumiditySensor(coordinator, name, entry_id, device_type),
+                S1PurifierSensorDSensor(coordinator, name, entry_id, device_type),
+                S1PurifierSensorSSensor(coordinator, name, entry_id, device_type),
+                S1FilterPreSensor(coordinator, name, entry_id, device_type),
+                S1FilterMediumSensor(coordinator, name, entry_id, device_type),
+                S1FilterCarbonSensor(coordinator, name, entry_id, device_type),
+                S1FilterDenseCarbonSensor(coordinator, name, entry_id, device_type),
+                S1FilterHepaSensor(coordinator, name, entry_id, device_type),
             ]
         )
         async_add_entities(entities, True)
@@ -703,22 +709,112 @@ class S1PurifierSpeedSensor(_BaseSensor):
         return self._data().get("purifier_speed")
 
 
-class S1PurifierHumiditySensor(_BaseSensor):
-    _attr_icon = "mdi:water-percent"
-    _attr_native_unit_of_measurement = PERCENTAGE
+class S1PurifierSensorDSensor(_BaseSensor):
+    # NOTE: field D from M9039 — exact meaning unconfirmed
+    _attr_icon = "mdi:gauge"
     _attr_state_class = SensorStateClass.MEASUREMENT
 
     def __init__(self, coordinator, name: str, entry_id: str, device_type: str) -> None:
         super().__init__(coordinator, name, entry_id, device_type)
-        self._attr_name = "Air Cleaner Humidity"
-        self._attr_unique_id = f"{entry_id}_s1_purifier_humidity"
+        self._attr_name = "Air Purifier Sensor D"
+        self._attr_unique_id = f"{entry_id}_s1_purifier_sensor_d"
 
     @property
     def available(self) -> bool:
-        if self._unavailable():
-            return False
-        return self._data().get("purifier_humidity") is not None
+        return (
+            self.coordinator.last_update_success
+            and not self._unavailable()
+            and self._data().get("purifier_sensor_d") is not None
+        )
 
     @property
     def native_value(self) -> Any:
-        return self._data().get("purifier_humidity")
+        return self._data().get("purifier_sensor_d")
+
+
+class S1PurifierSensorSSensor(_BaseSensor):
+    # NOTE: field S from M9039 — exact meaning unconfirmed
+    _attr_icon = "mdi:gauge"
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
+    def __init__(self, coordinator, name: str, entry_id: str, device_type: str) -> None:
+        super().__init__(coordinator, name, entry_id, device_type)
+        self._attr_name = "Air Purifier Sensor S"
+        self._attr_unique_id = f"{entry_id}_s1_purifier_sensor_s"
+
+    @property
+    def available(self) -> bool:
+        return (
+            self.coordinator.last_update_success
+            and not self._unavailable()
+            and self._data().get("purifier_sensor_s") is not None
+        )
+
+    @property
+    def native_value(self) -> Any:
+        return self._data().get("purifier_sensor_s")
+
+
+class _S1FilterSensor(_BaseSensor):
+    """Base class for AP2 filter lifetime sensors."""
+    _attr_icon = "mdi:air-filter"
+    _attr_native_unit_of_measurement = PERCENTAGE
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _filter_key: str = ""
+
+    @property
+    def available(self) -> bool:
+        return (
+            self.coordinator.last_update_success
+            and not self._unavailable()
+            and self._data().get(self._filter_key) is not None
+        )
+
+    @property
+    def native_value(self) -> Any:
+        return self._data().get(self._filter_key)
+
+
+class S1FilterPreSensor(_S1FilterSensor):
+    _filter_key = "filter_pre"
+
+    def __init__(self, coordinator, name: str, entry_id: str, device_type: str) -> None:
+        super().__init__(coordinator, name, entry_id, device_type)
+        self._attr_name = "Pre-filter Remaining"
+        self._attr_unique_id = f"{entry_id}_s1_filter_pre"
+
+
+class S1FilterMediumSensor(_S1FilterSensor):
+    _filter_key = "filter_medium"
+
+    def __init__(self, coordinator, name: str, entry_id: str, device_type: str) -> None:
+        super().__init__(coordinator, name, entry_id, device_type)
+        self._attr_name = "Medium Efficiency Filter Remaining"
+        self._attr_unique_id = f"{entry_id}_s1_filter_medium"
+
+
+class S1FilterCarbonSensor(_S1FilterSensor):
+    _filter_key = "filter_carbon"
+
+    def __init__(self, coordinator, name: str, entry_id: str, device_type: str) -> None:
+        super().__init__(coordinator, name, entry_id, device_type)
+        self._attr_name = "Activated Carbon Filter Remaining"
+        self._attr_unique_id = f"{entry_id}_s1_filter_carbon"
+
+
+class S1FilterDenseCarbonSensor(_S1FilterSensor):
+    _filter_key = "filter_dense_carbon"
+
+    def __init__(self, coordinator, name: str, entry_id: str, device_type: str) -> None:
+        super().__init__(coordinator, name, entry_id, device_type)
+        self._attr_name = "Ultra Dense Carbon Mesh Filter Remaining"
+        self._attr_unique_id = f"{entry_id}_s1_filter_dense_carbon"
+
+
+class S1FilterHepaSensor(_S1FilterSensor):
+    _filter_key = "filter_hepa"
+
+    def __init__(self, coordinator, name: str, entry_id: str, device_type: str) -> None:
+        super().__init__(coordinator, name, entry_id, device_type)
+        self._attr_name = "High Efficiency Filter Remaining"
+        self._attr_unique_id = f"{entry_id}_s1_filter_hepa"

--- a/custom_components/xtool/sensor.py
+++ b/custom_components/xtool/sensor.py
@@ -716,7 +716,7 @@ class S1PurifierSensorDSensor(_BaseSensor):
 
     def __init__(self, coordinator, name: str, entry_id: str, device_type: str) -> None:
         super().__init__(coordinator, name, entry_id, device_type)
-        self._attr_name = "Air Purifier Sensor D"
+        self._attr_name = "Air Cleaner Sensor D"
         self._attr_unique_id = f"{entry_id}_s1_purifier_sensor_d"
 
     @property
@@ -739,7 +739,7 @@ class S1PurifierSensorSSensor(_BaseSensor):
 
     def __init__(self, coordinator, name: str, entry_id: str, device_type: str) -> None:
         super().__init__(coordinator, name, entry_id, device_type)
-        self._attr_name = "Air Purifier Sensor S"
+        self._attr_name = "Air Cleaner Sensor S"
         self._attr_unique_id = f"{entry_id}_s1_purifier_sensor_s"
 
     @property

--- a/custom_components/xtool/sensor.py
+++ b/custom_components/xtool/sensor.py
@@ -9,7 +9,7 @@ from homeassistant.const import UnitOfTemperature, UnitOfTime, PERCENTAGE
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN, MANUFACTURER
+from .const import DOMAIN, MANUFACTURER, CONF_HAS_AP2
 from .coordinator_s1 import XToolS1Coordinator
 
 
@@ -50,17 +50,22 @@ async def async_setup_entry(
                 S1PositionYSensor(coordinator, name, entry_id, device_type),
                 S1FanASensor(coordinator, name, entry_id, device_type),
                 S1FanBSensor(coordinator, name, entry_id, device_type),
-                S1PurifierModelSensor(coordinator, name, entry_id, device_type),
-                S1PurifierSpeedSensor(coordinator, name, entry_id, device_type),
-                S1PurifierSensorDSensor(coordinator, name, entry_id, device_type),
-                S1PurifierSensorSSensor(coordinator, name, entry_id, device_type),
-                S1FilterPreSensor(coordinator, name, entry_id, device_type),
-                S1FilterMediumSensor(coordinator, name, entry_id, device_type),
-                S1FilterCarbonSensor(coordinator, name, entry_id, device_type),
-                S1FilterDenseCarbonSensor(coordinator, name, entry_id, device_type),
-                S1FilterHepaSensor(coordinator, name, entry_id, device_type),
             ]
         )
+        if entry.data.get(CONF_HAS_AP2, False):
+            entities.extend(
+                [
+                    S1PurifierModelSensor(coordinator, name, entry_id, device_type),
+                    S1PurifierSpeedSensor(coordinator, name, entry_id, device_type),
+                    S1PurifierSensorDSensor(coordinator, name, entry_id, device_type),
+                    S1PurifierSensorSSensor(coordinator, name, entry_id, device_type),
+                    S1FilterPreSensor(coordinator, name, entry_id, device_type),
+                    S1FilterMediumSensor(coordinator, name, entry_id, device_type),
+                    S1FilterCarbonSensor(coordinator, name, entry_id, device_type),
+                    S1FilterDenseCarbonSensor(coordinator, name, entry_id, device_type),
+                    S1FilterHepaSensor(coordinator, name, entry_id, device_type),
+                ]
+            )
         async_add_entities(entities, True)
         return
 

--- a/custom_components/xtool/sensor.py
+++ b/custom_components/xtool/sensor.py
@@ -10,6 +10,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN, MANUFACTURER
+from .coordinator_s1 import XToolS1Coordinator
 
 
 async def async_setup_entry(
@@ -34,6 +35,24 @@ async def async_setup_entry(
                 D1WorkingTimeSensor(coordinator, name, entry_id, device_type),
                 D1LineSensor(coordinator, name, entry_id, device_type),
                 D1MachineTypeSensor(coordinator, name, entry_id, device_type),
+            ]
+        )
+        async_add_entities(entities, True)
+        return
+
+    if device_type == "s1":
+        entities.extend(
+            [
+                S1StatusSensor(coordinator, name, entry_id, device_type),
+                S1FirmwareSensor(coordinator, name, entry_id, device_type),
+                S1JobFileSensor(coordinator, name, entry_id, device_type),
+                S1PositionXSensor(coordinator, name, entry_id, device_type),
+                S1PositionYSensor(coordinator, name, entry_id, device_type),
+                S1FanASensor(coordinator, name, entry_id, device_type),
+                S1FanBSensor(coordinator, name, entry_id, device_type),
+                S1PurifierModelSensor(coordinator, name, entry_id, device_type),
+                S1PurifierSpeedSensor(coordinator, name, entry_id, device_type),
+                S1PurifierHumiditySensor(coordinator, name, entry_id, device_type),
             ]
         )
         async_add_entities(entities, True)
@@ -530,3 +549,176 @@ class XToolMultiFunctionModuleSensor(_BaseSensor):
 
         mapping = {0: "Empty / Not synced", 22: "Embossing", 23: "Knife blade", 24: "Rotary blade"}
         return mapping.get(val_int, f"Unknown ({val_int})")
+
+
+# --- S1 ---
+
+class S1StatusSensor(_BaseSensor):
+    _attr_icon = "mdi:laser-pointer"
+
+    def __init__(self, coordinator, name: str, entry_id: str, device_type: str) -> None:
+        super().__init__(coordinator, name, entry_id, device_type)
+        self._attr_name = "Status"
+        self._attr_unique_id = f"{entry_id}_s1_status"
+
+    @property
+    def native_value(self) -> str:
+        if self._unavailable():
+            return "Unavailable"
+        raw = self._data().get("work_state_raw")
+        return XToolS1Coordinator.map_work_state(raw)
+
+
+class S1FirmwareSensor(_BaseSensor):
+    _attr_icon = "mdi:chip"
+
+    def __init__(self, coordinator, name: str, entry_id: str, device_type: str) -> None:
+        super().__init__(coordinator, name, entry_id, device_type)
+        self._attr_name = "Firmware Version"
+        self._attr_unique_id = f"{entry_id}_s1_firmware"
+
+    @property
+    def native_value(self) -> Any:
+        if self._unavailable():
+            return None
+        return self._data().get("firmware_version")
+
+
+class S1JobFileSensor(_BaseSensor):
+    _attr_icon = "mdi:file-outline"
+
+    def __init__(self, coordinator, name: str, entry_id: str, device_type: str) -> None:
+        super().__init__(coordinator, name, entry_id, device_type)
+        self._attr_name = "Job File"
+        self._attr_unique_id = f"{entry_id}_s1_job"
+
+    @property
+    def native_value(self) -> Any:
+        if self._unavailable():
+            return None
+        # API normalizes "NULL" -> None; None renders as unavailable in HA
+        return self._data().get("job_file")
+
+
+class S1PositionXSensor(_BaseSensor):
+    _attr_icon = "mdi:axis-x-arrow"
+    _attr_native_unit_of_measurement = "mm"
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
+    def __init__(self, coordinator, name: str, entry_id: str, device_type: str) -> None:
+        super().__init__(coordinator, name, entry_id, device_type)
+        self._attr_name = "Position X"
+        self._attr_unique_id = f"{entry_id}_s1_pos_x"
+
+    @property
+    def native_value(self) -> Any:
+        if self._unavailable():
+            return None
+        return self._data().get("pos_x")
+
+
+class S1PositionYSensor(_BaseSensor):
+    _attr_icon = "mdi:axis-y-arrow"
+    _attr_native_unit_of_measurement = "mm"
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
+    def __init__(self, coordinator, name: str, entry_id: str, device_type: str) -> None:
+        super().__init__(coordinator, name, entry_id, device_type)
+        self._attr_name = "Position Y"
+        self._attr_unique_id = f"{entry_id}_s1_pos_y"
+
+    @property
+    def native_value(self) -> Any:
+        if self._unavailable():
+            return None
+        return self._data().get("pos_y")
+
+
+class S1FanASensor(_BaseSensor):
+    _attr_icon = "mdi:fan"
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
+    def __init__(self, coordinator, name: str, entry_id: str, device_type: str) -> None:
+        super().__init__(coordinator, name, entry_id, device_type)
+        self._attr_name = "Fan A"
+        self._attr_unique_id = f"{entry_id}_s1_fan_a"
+
+    @property
+    def native_value(self) -> Any:
+        if self._unavailable():
+            return None
+        return self._data().get("fan_a")
+
+
+class S1FanBSensor(_BaseSensor):
+    _attr_icon = "mdi:fan"
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
+    def __init__(self, coordinator, name: str, entry_id: str, device_type: str) -> None:
+        super().__init__(coordinator, name, entry_id, device_type)
+        self._attr_name = "Fan B"
+        self._attr_unique_id = f"{entry_id}_s1_fan_b"
+
+    @property
+    def native_value(self) -> Any:
+        if self._unavailable():
+            return None
+        return self._data().get("fan_b")
+
+
+_PURIFIER_DEFAULT_MODEL = "xTool AP2"
+
+
+class S1PurifierModelSensor(_BaseSensor):
+    _attr_icon = "mdi:air-purifier"
+
+    def __init__(self, coordinator, name: str, entry_id: str, device_type: str) -> None:
+        super().__init__(coordinator, name, entry_id, device_type)
+        self._attr_name = "Air Cleaner Model"
+        self._attr_unique_id = f"{entry_id}_s1_purifier_model"
+
+    @property
+    def native_value(self) -> str:
+        # Use embedded ID if the device reports one, otherwise fall back to known model
+        return self._data().get("purifier_model") or _PURIFIER_DEFAULT_MODEL
+
+
+class S1PurifierSpeedSensor(_BaseSensor):
+    _attr_icon = "mdi:air-purifier"
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
+    def __init__(self, coordinator, name: str, entry_id: str, device_type: str) -> None:
+        super().__init__(coordinator, name, entry_id, device_type)
+        self._attr_name = "Air Cleaner Speed"
+        self._attr_unique_id = f"{entry_id}_s1_purifier_speed"
+
+    @property
+    def available(self) -> bool:
+        if self._unavailable():
+            return False
+        return self._data().get("purifier_speed") is not None
+
+    @property
+    def native_value(self) -> Any:
+        return self._data().get("purifier_speed")
+
+
+class S1PurifierHumiditySensor(_BaseSensor):
+    _attr_icon = "mdi:water-percent"
+    _attr_native_unit_of_measurement = PERCENTAGE
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
+    def __init__(self, coordinator, name: str, entry_id: str, device_type: str) -> None:
+        super().__init__(coordinator, name, entry_id, device_type)
+        self._attr_name = "Air Cleaner Humidity"
+        self._attr_unique_id = f"{entry_id}_s1_purifier_humidity"
+
+    @property
+    def available(self) -> bool:
+        if self._unavailable():
+            return False
+        return self._data().get("purifier_humidity") is not None
+
+    @property
+    def native_value(self) -> Any:
+        return self._data().get("purifier_humidity")

--- a/custom_components/xtool/switch.py
+++ b/custom_components/xtool/switch.py
@@ -25,8 +25,8 @@ async def async_setup_entry(
 
     entities: list[SwitchEntity] = []
 
-    # D1 has its own API stack -> no v2 peripheral switches here
-    if device_type == "d1":
+    # D1 and S1 have their own API stacks -> no v2 peripheral switches here
+    if device_type in ("d1", "s1"):
         async_add_entities(entities, True)
         return
 


### PR DESCRIPTION
# Add xTool S1 support with optional AP2 air cleaner

- New WebSocket-based coordinator and API for the S1 laser
- Sensors: status, firmware, job file, position X/Y, fan A/B
- Binary sensors: power, running, alarm, air cleaner running
- Optional AP2 air cleaner: speed, filter levels (5 stages),
  and two diagnostic sensors (D, S fields from M9039)
- Two-step config flow for S1 with AP2 accessory selection
- Fix missing _LOGGER arg in D1 coordinator super().__init__